### PR TITLE
Add command option to export only a set of chats

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Usage: ./sigexport.py [OPTIONS] [DEST]
 Options:
   -s, --source PATH  Path to Signal config and database
       --old PATH     Path to previous export to merge with
-  -c, --chat "NAME"  Names of specific chats (separate multiple chats by a comma)
+  -c, --chat "NAME"  Comma-separated chat names to include. These are contact names or group names
   -o, --overwrite    Flag to overwrite existing output
   -m, --manual       Flag to manually decrypt the database
   --help             Show this message and exit.

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Usage: ./sigexport.py [OPTIONS] [DEST]
 Options:
   -s, --source PATH  Path to Signal config and database
       --old PATH     Path to previous export to merge with
+  -c, --chat NAME    Display name of a specific chat (surround name with quotes if it contains spaces)
   -o, --overwrite    Flag to overwrite existing output
   -m, --manual       Flag to manually decrypt the database
   --help             Show this message and exit.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Usage: ./sigexport.py [OPTIONS] [DEST]
 Options:
   -s, --source PATH  Path to Signal config and database
       --old PATH     Path to previous export to merge with
-  -c, --chat NAME    Display name of a specific chat (surround name with quotes if it contains spaces)
+  -c, --chat "NAME"  Names of specific chats (separate multiple chats by a comma)
   -o, --overwrite    Flag to overwrite existing output
   -m, --manual       Flag to manually decrypt the database
   --help             Show this message and exit.

--- a/sigexport.py
+++ b/sigexport.py
@@ -177,7 +177,8 @@ def fetch_data(db_file, key, manual=False, chat=None):
 
     query = "SELECT type, id, e164, name, profileName, members FROM conversations"
     if (chat is not None):
-        query = query + f' WHERE name = "{chat}" OR profileName = "{chat}"'
+        chat = '","'.join(chat)
+        query = query + f' WHERE name IN ("{chat}") OR profileName IN ("{chat}")'
     c.execute(query)
     for result in c:
         is_group = result[0] == "group"
@@ -414,7 +415,7 @@ def merge_with_old(dest, old):
     "--source", "-s", type=click.Path(), help="Path to Signal source and database"
 )
 @click.option(
-    "--chat", "-c", type=click.Path(), help="Particular chat name to be exported"
+    "--chat", "-c", type=click.Path(), help="Set of chat names to be exported"
 )
 @click.option("--old", type=click.Path(), help="Path to previous export to merge with")
 @click.option(
@@ -453,6 +454,9 @@ def main(
         src = source_location()
     source = src / "config.json"
     db_file = src / "sql" / "db.sqlite"
+
+    if chat:
+        chat = chat.split(',')
 
     dest = Path(dest).expanduser()
     if not dest.is_dir():

--- a/sigexport.py
+++ b/sigexport.py
@@ -141,7 +141,7 @@ def make_simple(dest, conversations, contacts):
                 print(f"No attachments for a message: {name}")
 
 
-def fetch_data(db_file, key, manual=False):
+def fetch_data(db_file, key, manual=False, chat=None):
     """Load SQLite data into dicts."""
 
     contacts = {}
@@ -175,7 +175,10 @@ def fetch_data(db_file, key, manual=False):
             cursor.execute("PRAGMA cipher_hmac_algorithm = HMAC_SHA1")
             cursor.execute("PRAGMA cipher_kdf_algorithm = PBKDF2_HMAC_SHA1")
 
-    c.execute("SELECT type, id, e164, name, profileName, members FROM conversations")
+    query = "SELECT type, id, e164, name, profileName, members FROM conversations"
+    if (chat is not None):
+        query = query + f' WHERE name = "{chat}" OR profileName = "{chat}"'
+    c.execute(query)
     for result in c:
         is_group = result[0] == "group"
         cid = result[1]
@@ -209,7 +212,7 @@ def fetch_data(db_file, key, manual=False):
     for result in c:
         content = json.loads(result[0])
         cid = result[1]
-        if cid:
+        if cid and cid in convos:
             convos[cid].append(content)
 
     if db_file_decrypted.exists():
@@ -410,6 +413,9 @@ def merge_with_old(dest, old):
 @click.option(
     "--source", "-s", type=click.Path(), help="Path to Signal source and database"
 )
+@click.option(
+    "--chat", "-c", type=click.Path(), help="Particular chat name to be exported"
+)
 @click.option("--old", type=click.Path(), help="Path to previous export to merge with")
 @click.option(
     "--overwrite",
@@ -426,7 +432,7 @@ def merge_with_old(dest, old):
     help="Whether to manually decrypt the db",
 )
 def main(
-    dest, old=None, source=None, overwrite=False, manual=False,
+    dest, old=None, source=None, overwrite=False, manual=False, chat=None
 ):
     """
     Read the Signal directory and output attachments and chat files to DEST directory.
@@ -464,7 +470,7 @@ def main(
         print(f"Error: {source} not found in directory {src}")
         sys.exit(1)
 
-    convos, contacts = fetch_data(db_file, key, manual=manual)
+    convos, contacts = fetch_data(db_file, key, manual=manual, chat=chat)
     contacts = fix_names(contacts)
     convos = copy_attachments(src, dest, convos, contacts)
     make_simple(dest, convos, contacts)

--- a/sigexport.py
+++ b/sigexport.py
@@ -415,7 +415,7 @@ def merge_with_old(dest, old):
     "--source", "-s", type=click.Path(), help="Path to Signal source and database"
 )
 @click.option(
-    "--chat", "-c", type=click.Path(), help="Set of chat names to be exported"
+    "--chat", "-c", help="Comma-separated chat names to include. These are contact names or group names"
 )
 @click.option("--old", type=click.Path(), help="Path to previous export to merge with")
 @click.option(


### PR DESCRIPTION
This feature will let you export history of only a set of chats rather than all, specified by `-c`.