### PR TITLE
Change interpreter to python3

### DIFF
--- a/sigexport.py
+++ b/sigexport.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import json
 import sys


### PR DESCRIPTION
https://github.com/carderne/signal-export/issues/7

`python `usually refers to python2, which does not support  f-strings.

Changing this to `python3` prevents syntax errors