### PR TITLE
Fix on the fly de-cipher

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ Images are attached inline with `![name](path)` while other attachments (voice n
 This is converted to HTML at the end so it can be opened with any web browser. The stylesheet `.css` is still very basic but I'll get to it sooner or later.
 
 ## Installation
-There are issues with `sqlcipher`, and I haven't yet heard of anyone successfully using the original method (pipe up if you have!) so I'm going straight to the "advanced" method, which is more likely to work. Note that this will manually decrypt the database to a `db-decrypted.sqlite` file and use that to create the export (the decrypted database is deleted afterwards).
-
 First clone and install requirements (preferably into a virtualenv):
 ```
 git clone https://github.com/carderne/signal-export.git
@@ -47,12 +45,16 @@ sudo make install
 - Run `brew install openssl sqlcipher`
 
 ## Usage
-Assuming you followed the instructions above, you need to use the `--manual` flag in the tool.
-
 The following should work:
 ```
-./sigexport.py --manual outputdir
+./sigexport.py outputdir
 ```
+
+If you get an error:
+
+    pysqlcipher3.dbapi2.DatabaseError: file is not a database
+
+try adding the `--manual` option.
 
 The full options are below:
 ```

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Options:
   -s, --source PATH  Path to Signal config and database
       --old PATH     Path to previous export to merge with
   -c, --chat "NAME"  Comma-separated chat names to include. These are contact names or group names
+  --old PATH         Path to previous export to merge with
   -o, --overwrite    Flag to overwrite existing output
   -m, --manual       Flag to manually decrypt the database
   --help             Show this message and exit.

--- a/sigexport.py
+++ b/sigexport.py
@@ -170,10 +170,10 @@ def fetch_data(db_file, key, manual=False, chat=None):
         # param binding doesn't work for pragmas, so use a direct string concat
         for cursor in [c, c2]:
             cursor.execute(f"PRAGMA KEY = \"x'{key}'\"")
-            cursor.execute("PRAGMA cipher_page_size = 1024")
+            cursor.execute("PRAGMA cipher_page_size = 4096")
             cursor.execute("PRAGMA kdf_iter = 64000")
-            cursor.execute("PRAGMA cipher_hmac_algorithm = HMAC_SHA1")
-            cursor.execute("PRAGMA cipher_kdf_algorithm = PBKDF2_HMAC_SHA1")
+            cursor.execute("PRAGMA cipher_hmac_algorithm = HMAC_SHA512")
+            cursor.execute("PRAGMA cipher_kdf_algorithm = PBKDF2_HMAC_SHA512")
 
     query = "SELECT type, id, e164, name, profileName, members FROM conversations"
     if (chat is not None):


### PR DESCRIPTION
Fixed PRAGMAs (at least for latest Signal Desktop v1.40.0):
- page-size 1024-->4096,
- SHA1-->512 

Don't suggest to use `--manual` anymore. 