### PR TITLE
Account for case when 'None' is one of the contact names

### DIFF
--- a/sigexport.py
+++ b/sigexport.py
@@ -575,7 +575,10 @@ def main(
     print(f"\nFetching data from {db_file}")
     convos, contacts = fetch_data(db_file, key, manual=manual, chats=chats)
     if list_chats:
-        print("\n".join(sorted((v["name"] for v in contacts.values()))))
+        contact_names = [v["name"] for v in contacts.values()]
+        while None in contact_names:
+            contact_names.remove(None)
+        print("\n".join(sorted(contact_names)))
         return
 
     contacts = fix_names(contacts)

--- a/sigexport.py
+++ b/sigexport.py
@@ -575,10 +575,8 @@ def main(
     print(f"\nFetching data from {db_file}")
     convos, contacts = fetch_data(db_file, key, manual=manual, chats=chats)
     if list_chats:
-        contact_names = [v["name"] for v in contacts.values()]
-        while None in contact_names:
-            contact_names.remove(None)
-        print("\n".join(sorted(contact_names)))
+        names = sorted(v["name"] for v in contacts.values() if v["name"] is not None)
+        print("\n".join(names))
         return
 
     contacts = fix_names(contacts)


### PR DESCRIPTION
When trying to list contact names using the `--list-chats` options, an error was thrown in line 581:

```
TypeError: '<' not supported between instances of 'NoneType' and 'str'
```

The reason was that one of the contact names was `None`. To solve it, I added a loop that removes all `None` from the list of contact names. Afterwards, it worked.