### PR TITLE
Fix renaming of chats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 # OS generated files
 .DS_Store
 
+# IDE generated files
+.vscode
+
+# Output
 output/
 
 # Byte-compiled / optimized / DLL files

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# OS generated files
+.DS_Store
+
 output/
 
 # Byte-compiled / optimized / DLL files

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 beautifulsoup4
 Click>=7.0
+emoji>=1.4.2
 Markdown>=3.0
 pysqlcipher3>=1.0.3

--- a/sigexport.py
+++ b/sigexport.py
@@ -273,7 +273,7 @@ def fix_names(contacts):
             fixed_contact_name = contacts[key]["name"]
             if fixed_contact_name in fixed_contact_names:
                 name_differentiating_number = 2
-                while (fixed_contact_name+str(name_differentiating_number)) in fixed_contact_names:
+                while (fixed_contact_name + str(name_differentiating_number)) in fixed_contact_names:
                     name_differentiating_number += 1
                 fixed_contact_name += str(name_differentiating_number)
                 contacts[key]["name"] = fixed_contact_name

--- a/sigexport.py
+++ b/sigexport.py
@@ -217,7 +217,7 @@ def fetch_data(db_file, key, manual=False, chats=None):
     c.execute(query)
     for result in c:
         if log:
-            print(f"\tLoading SQL results for: {result[3]}")
+            print(f"\tLoading SQL results for: {result[3]}, aka {result[4]}")
         is_group = result[0] == "group"
         cid = result[1]
         contacts[cid] = {

--- a/sigexport.py
+++ b/sigexport.py
@@ -267,13 +267,17 @@ def fix_names(contacts):
     for key, item in contacts.items():
         contact_name = item["number"] if item["name"] is None else item["name"]
         if contacts[key]["name"] is not None:
-            contacts[key]["name"] = "".join(x for x in emoji.demojize(contact_name) if x.isalnum())
+            contacts[key]["name"] = "".join(
+                x for x in emoji.demojize(contact_name) if x.isalnum()
+            )
             if contacts[key]["name"] == "":
-                contacts[key]["name"] = 'unnamed'
+                contacts[key]["name"] = "unnamed"
             fixed_contact_name = contacts[key]["name"]
             if fixed_contact_name in fixed_contact_names:
                 name_differentiating_number = 2
-                while (fixed_contact_name + str(name_differentiating_number)) in fixed_contact_names:
+                while (
+                    fixed_contact_name + str(name_differentiating_number)
+                ) in fixed_contact_names:
                     name_differentiating_number += 1
                 fixed_contact_name += str(name_differentiating_number)
                 contacts[key]["name"] = fixed_contact_name

--- a/sigexport.py
+++ b/sigexport.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from datetime import datetime
 import re
 import sqlite3
+import emoji
 
 import click
 from pysqlcipher3 import dbapi2 as sqlcipher
@@ -261,12 +262,22 @@ def fetch_data(db_file, key, manual=False, chats=None):
 
 
 def fix_names(contacts):
-    """Remove non-filesystem-friendly characters from names."""
-
+    """Convert contact names to filesystem-friendly."""
+    fixed_contact_names = set()
     for key, item in contacts.items():
         contact_name = item["number"] if item["name"] is None else item["name"]
         if contacts[key]["name"] is not None:
-            contacts[key]["name"] = "".join(x for x in contact_name if x.isalnum())
+            contacts[key]["name"] = "".join(x for x in emoji.demojize(contact_name) if x.isalnum())
+            if contacts[key]["name"] == "":
+                contacts[key]["name"] = 'unnamed'
+            fixed_contact_name = contacts[key]["name"]
+            if fixed_contact_name in fixed_contact_names:
+                name_differentiating_number = 2
+                while (fixed_contact_name+str(name_differentiating_number)) in fixed_contact_names:
+                    name_differentiating_number += 1
+                fixed_contact_name += str(name_differentiating_number)
+                contacts[key]["name"] = fixed_contact_name
+            fixed_contact_names.add(fixed_contact_name)
 
     return contacts
 


### PR DESCRIPTION
This PR attempts to fix Issue #29.

I have modified the `fix_names` function to convert emojis into text before stripping all alphanumberic characters. This is done via an external dependency, the [emoji library](https://pypi.org/project/emoji/). Let me know if you prefer some other approach, perhaps it is just me who has lots of emojis in chat names 🤷‍♂️.

The other changes are changing empty string names to `unnamed` and appending a number to a chat if another chat with the same name already exists.

Thank you 😊!