### PR TITLE
Replace click.secho(gf=) with click.secho(fg=)

### DIFF
--- a/sigexport/main.py
+++ b/sigexport/main.py
@@ -516,20 +516,20 @@ def main(
             secho("Try running this from the command line:\ndocker run hello-world")
             raise Exit(1)
         except subprocess.CalledProcessError as e:
-            secho(f"Docker process failed, see logs below:\n{e}", gf=colors.RED)
+            secho(f"Docker process failed, see logs below:\n{e}", fg=colors.RED)
             raise Exit(1)
         except subprocess.TimeoutExpired:
             secho("Docker process timed out.")
             raise Exit(1)
         except json.JSONDecodeError:
-            secho("Unable to decode data from Docker, see logs below:", gf=colors.RED)
+            secho("Unable to decode data from Docker, see logs below:", fg=colors.RED)
             secho(p.stdout)
-            secho(p.stderr, gf=colors.RED)
+            secho(p.stderr, fg=colors.RED)
             raise Exit(1)
         except (KeyError, TypeError):
             secho(
                 "Unable to extract convos and contacts from Docker, see data below",
-                gf=colors.RED,
+                fg=colors.RED,
             )
             secho(data)
             raise Exit(1)


### PR DESCRIPTION
I can't find a kwarg to secho for `gf=`.  I was getting errors locally related to this.

```
style() got an unexpected keyword argument 'gf'
```

I believe the intention was to supply a foreground color with `fg=`.

Ref: https://click.palletsprojects.com/en/7.x/api/#click.style

Feel free to close if there's something going on with my local click version and `gf=` is actually correct.