### PR TITLE
Fix #78

### DIFF
--- a/sigexport/main.py
+++ b/sigexport/main.py
@@ -261,8 +261,8 @@ def create_html(dest: Path, msgs_per_page: int = 100) -> Iterable[Tuple[Path, st
                 secho(f"\tDoing html for {name}")
             path = sub / "index.md"
             # touch first
-            open(path, "a")
-            with path.open() as f:
+            open(path, "a", encoding="utf-8")
+            with path.open(encoding="utf-8") as f:
                 lines_raw = f.readlines()
             lines = lines_to_msgs(lines_raw)
             last_page = int(len(lines) / msgs_per_page)
@@ -580,7 +580,7 @@ def main(
 
     secho("Creating markdown files")
     for md_path, md_text in create_markdown(dest, convos, contacts, quote):
-        with md_path.open("a") as md_file:
+        with md_path.open("a", encoding="utf-8") as md_file:
             print(md_text, file=md_file)
     if old:
         secho(f"Merging old at {old} into output directory")
@@ -591,7 +591,7 @@ def main(
         if paginate <= 0:
             paginate = int(1e20)
         for ht_path, ht_text in create_html(dest, msgs_per_page=paginate):
-            with ht_path.open("w") as ht_file:
+            with ht_path.open("w", encoding="utf-8") as ht_file:
                 print(ht_text, file=ht_file)
     secho("Done!", fg=colors.GREEN)
 

--- a/sigexport/main.py
+++ b/sigexport/main.py
@@ -390,9 +390,9 @@ def merge_attachments(media_new: Path, media_old: Path) -> None:
 
 
 def merge_chat(path_new: Path, path_old: Path) -> None:
-    with path_old.open() as f:
+    with path_old.open(encoding="utf-8") as f:
         old_raw = f.readlines()
-    with path_new.open() as f:
+    with path_new.open(encoding="utf-8") as f:
         new_raw = f.readlines()
 
     try:
@@ -415,7 +415,7 @@ def merge_chat(path_new: Path, path_old: Path) -> None:
 
     merged = list(dict.fromkeys([m[0] + m[1] + m[2] for m in old + new]))
 
-    with path_new.open("w") as f:
+    with path_new.open("w", encoding="utf-8") as f:
         f.writelines(merged)
 
 


### PR DESCRIPTION
Fixes #78 (hopefully).

See https://github.com/carderne/signal-export/issues/78#issuecomment-1271525062 for details.

Note that I've only tested this fix on my system on Windows 10, while using Docker for WSL, and on a comparatively small Signal Desktop database with just a handful of conversations.
I just changed the encoding until the whole process ran through without errors and the output was correct.