### PR TITLE
support providing key instead of password

### DIFF
--- a/sigexport/data.py
+++ b/sigexport/data.py
@@ -14,6 +14,7 @@ from sigexport.logging import log
 def fetch_data(
     source_dir: Path,
     password: Optional[str],
+    key: Optional[str],
     chats: str,
     include_empty: bool,
 ) -> tuple[models.Convos, models.Contacts]:
@@ -21,11 +22,12 @@ def fetch_data(
     db_file = source_dir / "sql" / "db.sqlite"
     signal_config = source_dir / "config.json"
 
-    try:
-        key = crypto.get_key(signal_config, password)
-    except Exception:
-        secho("Failed to decrypt Signal password", fg=colors.RED)
-        raise Exit(1)
+    if key is None:
+        try:
+            key = crypto.get_key(signal_config, password)
+        except Exception:
+            secho("Failed to decrypt Signal password", fg=colors.RED)
+            raise Exit(1)
 
     log(f"Fetching data from {db_file}\n")
     contacts: models.Contacts = {}

--- a/sigexport/main.py
+++ b/sigexport/main.py
@@ -18,6 +18,7 @@ def main(
     source: OptionalPath = Option(None, help="Path to Signal source directory"),
     old: OptionalPath = Option(None, help="Path to previous export to merge"),
     password: OptionalStr = Option(None, help="Linux-only. Password to decrypt DB key"),
+    key: OptionalStr = Option(None, help="Linux-only. DB key, as found in the old config.json"),
     paginate: int = Option(
         100, "--paginate", "-p", help="Messages per page in HTML; set to 0 for infinite"
     ),
@@ -73,6 +74,7 @@ def main(
     convos, contacts = data.fetch_data(
         source_dir,
         password=password,
+        key=key,
         chats=chats,
         include_empty=include_empty,
     )


### PR DESCRIPTION
Hey,

I can't get the password on my system (some weird KDE mess, that somtimes also has no desktop environment). But I have the `key` from the config from a backup. This allows me to use the tool using the key instead of the password.

Might be helpful for others.