### PR TITLE
Add Flatpak config location

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ You can add `--source /path/to/source/dir/` if the script doesn't manage to find
 Default locations per OS are below.
 The directory should contain a folder called `sql` with `db.sqlite` inside it.
 - Linux: `~/.config/Signal/`
+- Linux Flatpak: `~/.var/app/org.signal.Signal/config/Signal`
 - macOS: `~/Library/Application Support/Signal/`
 - Windows: `~/AppData/Roaming/Signal/`
 


### PR DESCRIPTION
On non-Debian Linux distributions, some people install Signal through a community-managed Flatpak. I added a note in the README about where the Flatpak stores data.