### PR TITLE
add installation README for nix users

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ python -m sigexport C:\Temp\SignalExport
 ## 🪟 Installation: Windows
 If you need step-by-step instructions on things like enabling WSL2, please see the dedicated [Windows Installation](./INSTALLATION.md) instructions.
 
+## Installation nix/nixOS
+`signal-export` is packaged in nixpkgs, so you can run
+```bash
+nix-shell -I nixpkgs=channel:nixpkgs-unstable --packages signal-export --command 'sigexport ~/signal-chats'
+```
+)
+
 ## 🚀 Usage
 Please fully exit your Signal app before proceeding, otherwise you will likely encounter an `I/O disk` error, due to the message database being made read-only, as it was being accessed by the app.
 


### PR DESCRIPTION
Since signal-export got [updated](https://github.com/NixOS/nixpkgs/pull/353086) in nixpkgs, it's simple to use signal-export for nix users without pip hassle.

Since the maintainer of the nix package for signal-export [gets notified](https://github.com/NixOS/nixpkgs/pull/353086#pullrequestreview-2411708283) of new versions timely updated on nixpckgs can be expected.

I propose to document this.

Pros:
- even simpler for nix/nixOS users to use signal-export with a one-liner
- nix users get notified that the current version of signal-export is only available in unstable and hopefully do not get frustrated by the version 1.8.2 which is available in version 24.11 of nixOS

Cons:
- there are no installation instructions for other Linux distros
- the signal-export maintainer cannot make sure that the nix package stays up-to-date