### PR TITLE
Decrypt sqlcipher key on Windows

### DIFF
--- a/sigexport/data.py
+++ b/sigexport/data.py
@@ -20,11 +20,10 @@ def fetch_data(
 ) -> tuple[models.Convos, models.Contacts]:
     """Load SQLite data into dicts."""
     db_file = source_dir / "sql" / "db.sqlite"
-    signal_config = source_dir / "config.json"
 
     if key is None:
         try:
-            key = crypto.get_key(signal_config, password)
+            key = crypto.get_key(source_dir, password)
         except Exception:
             secho("Failed to decrypt Signal password", fg=colors.RED)
             raise Exit(1)


### PR DESCRIPTION
This should enable the tool to decrypt the key on Windows systems. ***NOTE*** I am _not_ a python programmer, feel free to make any changes you need to get this code to be more proper python.

Because the Windows code needs to access more files in Signal's application directory (not just the `config.json`), the `get_key` function now takes the application directory as an argument instead of the config file. All other changes are limited to the `if sys.platform == "win32":` codepath in crypto.py.

I've tried somewhat to mimic the style of the existing code, but couldn't bear to write so little comments. I restrained myself (could have written a lot more), but I imagine it's mostly because I'm so unfamiliar with python, comments explaining the code are helpful to me, but likely not to others. Feel free to remove all the comments.

This should fix #133

Thanks!