### PR TITLE
Sort merged messages by date and trim body of messages before inserting them as keys

### DIFF
--- a/sigexport/merge.py
+++ b/sigexport/merge.py
@@ -45,6 +45,11 @@ def merge_chat(new: list[models.Message], path_old: Path) -> list[models.Message
     # get rid of duplicates
     msg_dict = {m.comp(): m for m in old_msgs + new}
     merged = list(msg_dict.values())
+    
+    def get_date(val: any):
+        return val.date
+    
+    merged.sort(key=get_date)
 
     return merged
 

--- a/sigexport/models.py
+++ b/sigexport/models.py
@@ -126,7 +126,7 @@ class Message:
 
     def comp(self: Message) -> tuple[datetime, str, str]:
         date = self.date.replace(second=0, microsecond=0)
-        return (date, self.sender, self.body.replace("\n", "").replace(">", ""))
+        return (date, self.sender, self.body.replace("\n", "").replace(">", "").strip())
 
     def dict(self: Message) -> dict:
         msg_dict = asdict(self)


### PR DESCRIPTION
When I made backup today a large portion of my messages were duplicated, due to 2 reasons:

- Sometimes the body of older messages weren't trimmed/stripped.
![image](https://github.com/user-attachments/assets/717cf463-2787-40dc-8b42-a747dd7b35c3)
- Sometimes quoted messages were handled differently, at first the quote was part of the body, now the data model seems to have changed and there is a dedicated quote variable present.


It happened a lot with older messages from 2017/2018.
To fix the first issue I just trimmed the body message within the comparator.

The second issue is a little more tricky and isnt completely fixed with this PR:

- "Same" messages with different body layout (quote moved to quote variable) are not detected as same message
- So right now they get appended to the list as new messages, so right now you get a bunch of older messages at the end of the chatlog.
- As a workaround I just sort the list by the timestamp, then everything is ordered again, but some messages are duplicated now, not a pretty solution but at least better then having unordered messages.









