### PR TITLE
Fix #165 Adapt to new message layout in database after signalapp/Signal-Desktop@630a1fc

### DIFF
--- a/sigexport/data.py
+++ b/sigexport/data.py
@@ -66,32 +66,32 @@ def fetch_data(
         if not chats or (result[4] in chats_list or result[5] in chats_list):
             convos[cid] = []
 
-    query = "SELECT json, conversationId FROM messages ORDER BY sent_at"
+    query = "SELECT conversationId, type, json, id, body, sourceServiceId, timestamp, sent_at, serverTimestamp, hasAttachments, readStatus, seenStatus, json FROM messages ORDER BY sent_at"
     c.execute(query)
     for result in c:
-        res = json.loads(result[0])
-        cid = result[1]
+        cid = result[0]
+        type = result[1]
+        jsonLoaded = json.loads(result[2])
         if cid and cid in convos:
-            if res.get("type") in ["keychange", "profile-change", None]:
+            if type in ["keychange", "profile-change", None]:
                 continue
             con = models.RawMessage(
-                conversation_id=res["conversationId"],
-                id=res["id"],
-                type=res.get("type"),
-                body=res.get("body", ""),
-                contact=res.get("contact"),
-                source=res.get("sourceServiceId"),
-                timestamp=res.get("timestamp"),
-                sent_at=res.get("sent_at"),
-                server_timestamp=res.get("serverTimestamp"),
-                has_attachments=res.get("has_attachments", False),
-                attachments=res.get("attachments", []),
-                read_status=res.get("read_status"),
-                seen_status=res.get("seen_status"),
-                call_history=res.get("call_history"),
-                reactions=res.get("reactions", []),
-                sticker=res.get("sticker"),
-                quote=res.get("quote"),
+                conversation_id=cid,
+                id=result[3],
+                type=type,
+                body=result[4],
+                source=result[5],
+                timestamp=result[6],
+                sent_at=result[7],
+                server_timestamp=result[8],
+                has_attachments=result[9],
+                attachments=jsonLoaded.get("attachments", []),
+                read_status=result[10],
+                seen_status=result[11],
+                call_history=jsonLoaded.get("call_history"),
+                reactions=jsonLoaded.get("reactions", []),
+                sticker=jsonLoaded.get("sticker"),
+                quote=jsonLoaded.get("quote"),
             )
             convos[cid].append(con)
 

--- a/sigexport/models.py
+++ b/sigexport/models.py
@@ -15,7 +15,6 @@ class RawMessage:
 
     body: str
     type: str | None
-    contact: str | None
     source: Any | None
 
     timestamp: int | None


### PR DESCRIPTION
This is an attempt to adapt the extraction of messages after the changes done on Signal-Desktop side in signalapp/Signal-Desktop@630a1fc .

Most parts of the message are now normalized into database fields, from which I extract them.

There were a few things where it seems no message normalization took place yet and I needed to fall back to JSON, in particular:

* attachments
* call-history
* reactions
* sticker
* quote

I also could not figure out where `contact` went to, but I noticed that there do not appear to be any remaining usages of it in `sigexport`'s code, so I just dropped it.

It seems that *all* messages have the new fields (they seem to be automatically "hydrated" on migration from an older version), and older messages only retain the original JSON in addition. Therefore it's not necessary to handle old messages in one way and new ones in the other. (Smart of the Signal team.)

What is lacking in this commit is the testing side. I did re-export my chats and run a diff, so that might cover a fair share of use cases, but no guarantees whatsoever that I really have used all the functionality signal has to offer at least once; most likely, I didn't.

Also, I'd like to point out that I'm a noob both in Python as a language and in the signalapp/Signal-Desktop and carderne/sigexport as a codebase and database structure, so take it with a grain of salt.