### PR TITLE
Do not export disappearing messages by default

### DIFF
--- a/sigexport/main.py
+++ b/sigexport/main.py
@@ -39,6 +39,11 @@ def main(
     include_empty: bool = Option(
         False, "--include-empty", help="Whether to include empty chats"
     ),
+    include_disappearing: bool = Option(
+        False,
+        "--include-disappearing",
+        help="Whether to include disappearing messages",
+    ),
     overwrite: bool = Option(
         False,
         "--overwrite/--no-overwrite",
@@ -79,6 +84,7 @@ def main(
         key=key,
         chats=chats,
         include_empty=include_empty,
+        include_disappearing=include_disappearing,
     )
 
     if list_chats:


### PR DESCRIPTION
Resolves https://github.com/carderne/signal-export/issues/167.

This is based on top of https://github.com/carderne/signal-export/pull/168 as message exports do not work at all for me without that. The additional changes are 3103dfaaf74b8579be7df680aafc1e144f0311cf.

By the way, would anyone happen to know why I always just get the error `file is encrypted or is not a database` when trying to use `sqlcipher ~/.config/Signal/sql/db.sqlite` to edit the database, and running exactly the same set of commands from signal-export, but if I use the Python library methods then it works fine? This was somewhat of an inconvenience when testing.

```
% sqlcipher ~/.config/Signal/sql/db.sqlite
SQLCipher version 3.15.2 2016-11-28 19:13:37
Enter ".help" for instructions
Enter SQL statements terminated with a ";"
sqlite> PRAGMA KEY = "x'<same value as used in the code>'"; PRAGMA cipher_page_size = 4096; PRAGMA kdf_iter = 64000; PRAGMA cipher_hmac_algorithm = HMAC_SHA512; PRAGMA cipher_kdf_algorithm = PBKDF2_HMAC_SHA512;
sqlite> SELECT type, id, serviceId, e164, name, profileName, members FROM conversations;
Error: file is encrypted or is not a database
```
