### PR TITLE
Add suggestion to use pipx

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ This is converted to HTML at the end so it can be opened with any web browser. T
 2. Install this package:
 ```bash
 pip install signal-export
+
+# ...if you have the "pipx" command available, you're probably better off installing with "pipx install signal-export"
 ```
 
 3. Then run the script!


### PR DESCRIPTION
This works, too! :)

```
~ ❯ pipx install signal-export
  installed package signal-export 3.5.1, installed using Python 3.12.3
  These apps are now globally available
    - sigexport
done! ✨ 🌟 ✨
```