### PR TITLE
Update README instructions for NixOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,10 @@ If you need step-by-step instructions on things like enabling WSL2, please see t
 nix-shell -I nixpkgs=channel:nixpkgs-unstable --packages signal-export --command 'sigexport ~/signal-chats'
 ```
 
-If you get an error message about `secret-tool` not being found, you probably need to install `libsecret-tools` via your Linux package manager.
+If you get an error message about `secret-tool` not being found, you probably need to install `libsecret-tools` via your Linux package manager. If you get this on NixOS then just add `libsecret` in the previous command
+```bash
+nix-shell -I nixpkgs=channel:nixpkgs-unstable --packages signal-export libsecret --command 'sigexport ~/signal-chats'
+```
 
 ## 🚀 Usage
 Please fully exit your Signal app before proceeding, otherwise you will likely encounter an `I/O disk` error, due to the message database being made read-only, as it was being accessed by the app.


### PR DESCRIPTION
Its inconvenient for NixOS users to edit their `/etc/nixos/` configurations just to add a single dependency for signal-export. So This PR just updates the instructions with `libsecret` (`libsecret-tools` but it has a different name in NixOS) package added to the same nix-shell