### PR TITLE
Support attachments copy for database version >= 1360

### DIFF
--- a/sigexport/files.py
+++ b/sigexport/files.py
@@ -188,6 +188,7 @@ def copy_attachments(
                         .replace(",", "")
                         .replace(":", "-")
                         .replace("|", "-")
+                        .replace("*", "_")
                     )
                     # account for erroneous backslash in path
                     try:

--- a/sigexport/main.py
+++ b/sigexport/main.py
@@ -117,7 +117,7 @@ def main(
     contacts = utils.fix_names(contacts)
 
     secho("Copying and renaming attachments")
-    files.copy_attachments(source_dir, dest, convos, contacts)
+    files.copy_attachments(source_dir, dest, convos, contacts, password, key)
 
     if json_output and old:
         secho(


### PR DESCRIPTION
Fixes #174

Also includes a second commit that fixes an issue I encountered while testing this fix on Windows, where one of the attachments' filename has a `*` character and caused a crash.
I added a `.replace()` call to handle it.