### PR TITLE
Add support for filtering messages by date via cli

### DIFF
--- a/sigexport/main.py
+++ b/sigexport/main.py
@@ -45,6 +45,16 @@ def main(
         "--include-disappearing",
         help="Whether to include disappearing messages",
     ),
+    start_date: Optional[int] = Option(
+        None,
+        "--start",
+        help="Start date as Unix timestamp in milliseconds (e.g., 1751328000000)",
+    ),
+    end_date: Optional[int] = Option(
+        None,
+        "--end",
+        help="End date as Unix timestamp in milliseconds (e.g., 1754006399999)",
+    ),
     overwrite: bool = Option(
         False,
         "--overwrite/--no-overwrite",
@@ -68,6 +78,10 @@ def main(
     Example to export all to a directory:
 
         sigexport ~/outputdir
+
+    Example to export messages within a specific date range:
+
+        sigexport ~/outputdir --start 1751328000000 --end 1754006399999
     """
     logging.verbose = verbose
 
@@ -91,6 +105,8 @@ def main(
         chats=chats,
         include_empty=include_empty,
         include_disappearing=include_disappearing,
+        start_date=start_date,
+        end_date=end_date,
     )
 
     if list_chats:


### PR DESCRIPTION
This PR adds support for filtering messages by date via the CLI (https://github.com/carderne/signal-export/issues/183)

Two CLI arguments are added: `--start` and `--end`, each of which are optional and accept Unix millisecond timestamps.

Example usage:

```
sigexport --start 1751328000000 --end 1754006399999
to export between July 1st 2025 at 12:00 am UTC to July 31st 2025 at 11:59:59 pm UTC

sigexport --start 1751328000000
to export from July 1st 2025 at 12:00:00 am UTC to the current time

sigexport --end 1751328000000
to export from the beginning of time to July 1st 2025 at 12:00:00 am UTC
```

I tested all three variations and it works great. I'd love if I can get an extra check from someone else though. 

