### PR TITLE
Add --no-attachments flag to skip copying attachments

### DIFF
--- a/sigexport/main.py
+++ b/sigexport/main.py
@@ -67,10 +67,8 @@ def main(
         "--chat-members",
         help="Export membership information for all chats (or for a subset of chats given by the --chats option)",
     ),
-    no_attachments: bool = Option(
-        False,
-        "--no-attachments",
-        help="Skip copying attachments",
+    attachments: bool = Option(
+        True, "--attachments/--no-attachments", help="Whether to copy attachments"
     ),
     _: bool = Option(False, "--version", callback=utils.version_callback),
 ) -> None:
@@ -141,7 +139,7 @@ def main(
 
     contacts = utils.fix_names(contacts)
 
-    if not no_attachments:
+    if attachments:
         secho("Copying and renaming attachments")
         files.copy_attachments(source_dir, dest, convos, contacts, password, key)
 


### PR DESCRIPTION
Hey there,

I ran into an error when using this because of some issues with my attachments.

Rather than fix them (which may be a separate issue) I would rather actually just download everything without attachments, so I worked with Claude to add support for that. 

Thanks so much for your work on this repo!

## Summary
- Adds a `--no-attachments` CLI flag that skips the attachment copying/decryption step
- Useful when attachments cause errors (e.g. filenames too long) or when only conversation text is needed

## Test plan
- [ ] Run `sigexport --no-attachments ~/output` and verify attachments are skipped
- [ ] Run `sigexport ~/output` and verify default behavior (attachments copied) is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)