### PR TITLE
Escape strings in HTML, remove Markdown parser

### DIFF
--- a/sigexport/html.py
+++ b/sigexport/html.py
@@ -1,9 +1,9 @@
+import html
 import os
 import re
 import shutil
 from pathlib import Path
 
-import markdown
 from bs4 import BeautifulSoup
 from typer import secho
 
@@ -64,18 +64,14 @@ def create_html(
         reactions = " ".join(f"{r.name}: {r.emoji}" for r in msg.reactions)
         quote = ""
         if msg.quote:
-            quote = f"<div class=quote>{msg.quote.replace('>', '')}</div>"
+            quote = templates.quote.format(quote=html.escape(msg.quote))
 
         body = msg.body
-        try:
-            body = markdown.Markdown().convert(body)
-        except RecursionError:
-            log(f"Maximum recursion on message {body}, not converted")
 
         # links
         p = re.compile(r"(https{0,1}://\S*)")
         a_template = r"<a href='\1' target='_blank'>\1</a> "
-        body = re.sub(p, a_template, body)
+        body = re.sub(p, a_template, html.escape(body))
 
         soup = BeautifulSoup(body, "html.parser")
         # attachments
@@ -96,12 +92,12 @@ def create_html(
         cl = "msg me" if sender == "Me" else "msg"
         ht_content += templates.message.format(
             cl=cl,
-            date=date,
-            time=time,
-            sender=sender,
+            date=html.escape(date),
+            time=html.escape(time),
+            sender=html.escape(sender),
             quote=quote,
             body=soup,
-            reactions=reactions,
+            reactions=html.escape(reactions),
         )
     ht_text = templates.html.format(
         name=name,

--- a/sigexport/style.css
+++ b/sigexport/style.css
@@ -87,6 +87,7 @@ div {
     display: block;
     margin-left: 3em;
     word-wrap: break-word;
+    white-space: pre-wrap;
 }
 
 figure > label > img, video {
@@ -145,4 +146,5 @@ label > img {
     background-color: #f7f6ff;
     width: 50%;
     padding: 1rem;
+    white-space: pre-wrap;
 }

--- a/sigexport/templates.py
+++ b/sigexport/templates.py
@@ -21,14 +21,18 @@ html = """
 </html>
 """
 
+quote = """
+    <p class=quote>{quote}</p>
+"""
+
 message = """
 <div class='{cl}'>
     <span class=date>{date}</span>
     <span class=time>{time}</span>
     <span class=sender>{sender}</span>
     {quote}
-    <span class=body>{body}</span>
-    <span class=reaction>{reactions}</span>
+    <p class=body>{body}</p>
+    <p class=reaction>{reactions}</p>
 </div>
 """
 


### PR DESCRIPTION
EDIT: The bug occurs in GitHubs user interface as well XD. That's why I format it as plaintext.

```
The text "<<Details nice to have>> Please read" gets rendered
as '<details nice="" to="" have=""> Please read' because the
combination of a Markdown parser and HTML parser fails if unsafe
characters are to be rendered in the output template.
```

Signal does not support Markdown, therefore I removed it. As a replacement, I set white-space:pre-wrap in CSS.

This commit adds escaping for many output strings (I don't guarantee that everything which needs escaping is escaped).

In addition, I changed some HTML tags from <span> to <p>.

From my point of view, *signal-export* should switch to a proper template system. My personal preference is Jinja2 but this pull request aims to fix the greates issues and make the tool work for me.