### PR TITLE
Fix call direction by reading from callsHistory table

### DIFF
--- a/sigexport/create.py
+++ b/sigexport/create.py
@@ -1,8 +1,59 @@
 import re
 from pathlib import Path
+from typing import Any
 
 from sigexport import models, utils
 from sigexport.logging import log
+
+
+def _format_call(call_history: dict[str, Any] | None) -> str:
+    """Format a human-readable call description from call_history data."""
+    if not call_history:
+        return "Outgoing call"
+
+    # Legacy format (older Signal versions)
+    if "wasIncoming" in call_history and "direction" not in call_history:
+        return "Incoming call" if call_history["wasIncoming"] else "Outgoing call"
+
+    direction = call_history.get("direction", "")
+    status = call_history.get("status", "")
+    call_type = (call_history.get("callType") or "").lower()  # "audio" or "video"
+    started_ts = call_history.get("timestamp")
+    ended_ts = call_history.get("endedTimestamp")
+
+    # Duration string (only if call was accepted and we have both timestamps)
+    duration_str = ""
+    if status == "Accepted" and started_ts and ended_ts and ended_ts > started_ts:
+        total_secs = (ended_ts - started_ts) // 1000
+        mins, secs = divmod(total_secs, 60)
+        duration_str = f"{mins}m {secs}s" if mins else f"{secs}s"
+
+    label = f"{call_type} call" if call_type else "call"
+    label = label.replace("audio", "voice")
+
+    if direction == "Incoming":
+        if status == "Accepted":
+            detail = f"accepted, {duration_str}" if duration_str else "accepted"
+            return f"Incoming {label} ({detail})"
+        elif status == "Missed":
+            return f"Missed {label}"
+        elif status == "Declined":
+            return f"Incoming {label} (declined)"
+        else:
+            return f"Incoming {label} ({status.lower()})" if status else f"Incoming {label}"
+    elif direction == "Outgoing":
+        if status == "Accepted":
+            detail = f"accepted, {duration_str}" if duration_str else "accepted"
+            return f"Outgoing {label} ({detail})"
+        elif status in ("Missed", "NotAccepted"):
+            return f"Outgoing {label} (unanswered)"
+        elif status == "Declined":
+            return f"Outgoing {label} (declined by recipient)"
+        else:
+            return f"Outgoing {label} ({status.lower()})" if status else f"Outgoing {label}"
+    else:
+        # Fallback
+        return "Incoming call" if call_history.get("wasIncoming") else "Outgoing call"
 
 
 def create_message(
@@ -18,11 +69,7 @@ def create_message(
     log(f"\t\tDoing {name}, msg: {date}")
 
     if msg.type == "call-history":
-        body = (
-            "Incoming call"
-            if msg.call_history and msg.call_history["wasIncoming"]
-            else "Outgoing call"
-        )
+        body = _format_call(msg.call_history)
     else:
         body = msg.body or ""
 
@@ -31,6 +78,8 @@ def create_message(
 
     sender = "No-Sender"
     if msg.type == "outgoing":
+        sender = "Me"
+    elif msg.type == "call-history" and msg.call_history and msg.call_history.get("direction") == "Outgoing":
         sender = "Me"
     else:
         try:

--- a/sigexport/data.py
+++ b/sigexport/data.py
@@ -12,6 +12,21 @@ from sigexport import crypto, models
 from sigexport.logging import log
 
 
+def _call_history(
+    jsonLoaded: dict, call_directions: dict[str, dict]
+) -> dict | None:
+    """Build a call_history dict from the callsHistory table or legacy JSON fields."""
+    # Try legacy JSON keys first (older Signal versions)
+    result = jsonLoaded.get("call_history") or jsonLoaded.get("callHistoryDetails")
+    if result:
+        return result
+    # Modern Signal: direction is in a separate callsHistory table
+    call_id = jsonLoaded.get("callId")
+    if call_id and call_id in call_directions:
+        return call_directions[call_id]
+    return None
+
+
 def fetch_data(
     source_dir: Path,
     password: Optional[str],
@@ -50,6 +65,22 @@ def fetch_data(
     c.execute("PRAGMA kdf_iter = 64000")
     c.execute("PRAGMA cipher_hmac_algorithm = HMAC_SHA512")
     c.execute("PRAGMA cipher_kdf_algorithm = PBKDF2_HMAC_SHA512")
+
+    # Load call info from callsHistory table (keyed by callId)
+    call_directions: dict[str, dict] = {}
+    try:
+        c2 = db.cursor()
+        c2.execute("SELECT callId, direction, status, type, timestamp, endedTimestamp FROM callsHistory")
+        for row in c2.fetchall():
+            call_directions[row[0]] = {
+                "direction": row[1],
+                "status": row[2],
+                "callType": row[3],
+                "timestamp": row[4],
+                "endedTimestamp": row[5],
+            }
+    except Exception:
+        pass
 
     query = "SELECT type, id, serviceId, e164, name, profileName, members FROM conversations"
     c.execute(query)
@@ -142,7 +173,7 @@ def fetch_data(
                 attachments=jsonLoaded.get("attachments", []),
                 read_status=result[10],
                 seen_status=result[11],
-                call_history=jsonLoaded.get("call_history"),
+                call_history=_call_history(jsonLoaded, call_directions),
                 reactions=jsonLoaded.get("reactions", []),
                 sticker=jsonLoaded.get("sticker"),
                 quote=jsonLoaded.get("quote"),

--- a/sigexport/data.py
+++ b/sigexport/data.py
@@ -15,16 +15,51 @@ from sigexport.logging import log
 def _call_history(
     jsonLoaded: dict, call_directions: dict[str, dict]
 ) -> dict | None:
-    """Build a call_history dict from the callsHistory table or legacy JSON fields."""
-    # Try legacy JSON keys first (older Signal versions)
-    result = jsonLoaded.get("call_history") or jsonLoaded.get("callHistoryDetails")
-    if result:
-        return result
-    # Modern Signal: direction is in a separate callsHistory table
+    """Build a call_history dict by combining legacy JSON and callsHistory data."""
+    legacy = jsonLoaded.get("call_history") or jsonLoaded.get("callHistoryDetails")
+    call_row = None
+
     call_id = jsonLoaded.get("callId")
-    if call_id and call_id in call_directions:
-        return call_directions[call_id]
+    if call_id is not None:
+        call_row = call_directions.get(str(call_id))
+
+    # Merge when both are available so modern direction/status from callsHistory wins
+    if isinstance(legacy, dict) and isinstance(call_row, dict):
+        return {**legacy, **call_row}
+    if isinstance(call_row, dict):
+        return call_row
+    if isinstance(legacy, dict):
+        return legacy
+
     return None
+
+
+def _load_call_directions(db: dbapi2.Connection) -> dict[str, dict]:
+    """Load call info from callsHistory table (if present in this Signal schema)."""
+    call_directions: dict[str, dict] = {}
+    try:
+        c2 = db.cursor()
+        c2.execute("SELECT callId, direction, status, type, timestamp, endedTimestamp FROM callsHistory")
+        for row in c2.fetchall():
+            call_directions[str(row[0])] = {
+                "direction": row[1],
+                "status": row[2],
+                "callType": row[3],
+                "timestamp": row[4],
+                "endedTimestamp": row[5],
+            }
+    except dbapi2.OperationalError as e:
+        err = str(e).lower()
+        if "no such table" in err and "callshistory" in err:
+            log("\tcallsHistory table not found; using legacy call metadata only")
+        else:
+            secho(f"Failed to query callsHistory table: {e}", fg=colors.RED)
+            raise Exit(1) from e
+    except Exception as e:
+        secho(f"Unexpected error while querying callsHistory table: {e}", fg=colors.RED)
+        raise Exit(1) from e
+
+    return call_directions
 
 
 def fetch_data(
@@ -66,21 +101,7 @@ def fetch_data(
     c.execute("PRAGMA cipher_hmac_algorithm = HMAC_SHA512")
     c.execute("PRAGMA cipher_kdf_algorithm = PBKDF2_HMAC_SHA512")
 
-    # Load call info from callsHistory table (keyed by callId)
-    call_directions: dict[str, dict] = {}
-    try:
-        c2 = db.cursor()
-        c2.execute("SELECT callId, direction, status, type, timestamp, endedTimestamp FROM callsHistory")
-        for row in c2.fetchall():
-            call_directions[row[0]] = {
-                "direction": row[1],
-                "status": row[2],
-                "callType": row[3],
-                "timestamp": row[4],
-                "endedTimestamp": row[5],
-            }
-    except Exception:
-        pass
+    call_directions = _load_call_directions(db)
 
     query = "SELECT type, id, serviceId, e164, name, profileName, members FROM conversations"
     c.execute(query)


### PR DESCRIPTION
All calls are currently exported as "Outgoing call" regardless of whether they were actually incoming or outgoing (Tested on Signal 8.7.0 Apple Silicon)

**What I changed**

- Calls now correctly show as "Incoming" or "Outgoing"
- The call status is included, e.g.:
  - `Incoming voice call (accepted)`
  - `Missed voice call`
  - `Outgoing video call (unanswered)`
  - `Outgoing voice call (declined by recipient)`
- Outgoing calls now show `Me` as the sender, consistent with how outgoing text messages appear

It's backwards compatible, so older Signal versions and all other platforms (Windows, Linux) are unaffected.