### PR TITLE
Add support for more media formats

### DIFF
--- a/sigexport/models.py
+++ b/sigexport/models.py
@@ -71,6 +71,9 @@ def is_image(p: str) -> bool:
         "gif",
         "tif",
         "tiff",
+        "webp",
+        "apng",
+        "svg",
     ]
 
 
@@ -79,6 +82,11 @@ def is_audio(p: str) -> bool:
     return len(suffix) > 1 and suffix[-1] in [
         "m4a",
         "aac",
+        "mp3",
+        "ogg",
+        "opus",
+        "wav",
+        "flac",
     ]
 
 
@@ -86,6 +94,11 @@ def is_video(p: str) -> bool:
     suffix = p.split(".")
     return len(suffix) > 1 and suffix[-1] in [
         "mp4",
+        "mov",
+        "mkv",
+        "mpeg",
+        "webm",
+        "qt",
     ]
 
 


### PR DESCRIPTION
Makes it so that media files of extensions listed below embed properly in HTML exports.

Audio:
- mp3
- ogg
- opus
- wav
- flac

Video:
- mpeg
- webm
- qt
- mov
- mkv

Image:
- webp
- apng
- svg