### PR TITLE
Fix KeyError when sticker message lacks emoji/extension field

### DIFF
--- a/sigexport/create.py
+++ b/sigexport/create.py
@@ -130,8 +130,8 @@ def create_message(
             str(msg.sticker["stickerId"]),
             msg.sticker["packId"],
             msg.sticker["packKey"],
-            msg.sticker["emoji"],
-            msg.sticker["extension"],
+            msg.sticker.get("emoji", ""),
+            msg.sticker.get("extension", "unknown"),
         )
 
     quote = ""

--- a/sigexport/files.py
+++ b/sigexport/files.py
@@ -343,7 +343,7 @@ def check_stickers_existence(
                     str(msg.sticker["stickerId"]),
                     msg.sticker["packId"],
                     msg.sticker["packKey"],
-                    msg.sticker["emoji"],
+                    msg.sticker.get("emoji", ""),
                 )
                 if m_sticker.get_path(dest):
                     msg.sticker["extension"] = m_sticker.extension


### PR DESCRIPTION
Fixes the crashes reported in #210. Uses .get() with defaults instead of direct dict indexing for the optional 'emoji' and 'extension' sticker fields, matching the existing fallback pattern in files.py.