### PR TITLE
Fix merge dropping chats from incomplete old exports

### DIFF
--- a/sigexport/merge.py
+++ b/sigexport/merge.py
@@ -59,7 +59,7 @@ def merge_with_old(
     chat_dict: models.Chats, contacts: models.Contacts, dest: Path, old: Path
 ) -> models.Chats:
     """Main function for merging new and old."""
-    new_chat_dict: models.Chats = {}
+    new_chat_dict = chat_dict.copy()
     for key, msgs in chat_dict.items():
         name = contacts[key].name
         # some contact names are None

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -1,0 +1,36 @@
+from datetime import datetime
+from pathlib import Path
+
+from sigexport import merge, models
+
+
+def test_merge_keeps_new_chat_when_old_markdown_is_missing(tmp_path: Path) -> None:
+    message = models.Message(
+        date=datetime(2026, 1, 1),
+        sender="Alice",
+        body="new message",
+        quote="",
+        sticker=None,
+        reactions=[],
+        attachments=[],
+    )
+    chats = {"contact": [message]}
+    contacts = {
+        "contact": models.Contact(
+            id="contact",
+            serviceId="service",
+            name="Alice",
+            number="",
+            profile_name="",
+            is_group=False,
+            members=None,
+        )
+    }
+    destination = tmp_path / "new"
+    old = tmp_path / "old"
+    (destination / "Alice" / "media").mkdir(parents=True)
+    (old / "Alice" / "media").mkdir(parents=True)
+
+    merged = merge.merge_with_old(chats, contacts, destination, old)
+
+    assert merged == chats


### PR DESCRIPTION
Closes #190

Merging now starts from all newly exported chats, so a conversation is not dropped when its old export directory has no `chat.md` or legacy `index.md`. A regression test covers the incomplete-old-export case.

Tested with `pytest`, Ruff, formatting, and ty.
