### PR TITLE
fix: attachment decryption crash, and phantom sticker links

### DIFF
--- a/sigexport/create.py
+++ b/sigexport/create.py
@@ -131,7 +131,7 @@ def create_message(
             msg.sticker["packId"],
             msg.sticker["packKey"],
             msg.sticker.get("emoji", ""),
-            msg.sticker.get("extension", "unknown"),
+            msg.sticker.get("extension"),
         )
 
     quote = ""

--- a/sigexport/files.py
+++ b/sigexport/files.py
@@ -355,4 +355,4 @@ def check_stickers_existence(
                         f"Not found: sticker {m_sticker.id} from pack '{m_sticker.packId}' used in conversation '{name}' at {date}, skipping",
                         fg=colors.MAGENTA,
                     )
-                    msg.sticker["extension"] = "unknown"
+                    msg.sticker["extension"] = None

--- a/sigexport/files.py
+++ b/sigexport/files.py
@@ -72,12 +72,14 @@ def decrypt_attachment(
     if len(decrypted_data) < int(att["size"]):
         raise ValueError("Invalid attachment data length")
 
+    dst_path_str = str(dst_path)
     if detect_file_type:
-        dst_path_str = str(dst_path)
         try:
             ext = filetype.guess_extension(decrypted_data)
         except TypeError:
             raise ValueError("Unsupported attachment file type")
+        if ext is None:
+            raise ValueError("Could not detect attachment file type")
 
         dst_path_str += "." + ext
 

--- a/sigexport/html.py
+++ b/sigexport/html.py
@@ -99,9 +99,9 @@ def create_html(
 
             if sticker_path:
                 src = f"../{sticker_path}"
-                temp = templates.figure.format(src=src, alt=msg.sticker.emoji)
+                temp = templates.figure.format(src=src, alt=msg.sticker.label)
             else:
-                temp = "(( " + msg.sticker.emoji + " ))"
+                temp = "(( " + msg.sticker.label + " ))"
 
             if temp:
                 soup.append(BeautifulSoup(temp, "html.parser"))

--- a/sigexport/models.py
+++ b/sigexport/models.py
@@ -57,6 +57,11 @@ class Sticker:
     emoji: str
     extension: str | None = None
 
+    @property
+    def label(self: Sticker) -> str:
+        """Text stand-in for the sticker, as not every sticker has an emoji."""
+        return self.emoji or "sticker"
+
     def get_path(self: Sticker, export_dest: Path | None = None) -> str | None:
         if not export_dest:
             if self.extension:
@@ -166,9 +171,9 @@ class Message:
         if self.sticker:
             sticker_path = self.sticker.get_path()
             if sticker_path:
-                body += f"[{self.sticker.emoji}](../{sticker_path})  "
+                body += f"[{self.sticker.label}](../{sticker_path})  "
             else:
-                body = body + "\n(( " + self.sticker.emoji + " ))"
+                body = body + "\n(( " + self.sticker.label + " ))"
 
         for att in self.attachments:
             if is_image(att.path):

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -1,8 +1,33 @@
+import base64
+import hashlib
+import hmac
 from pathlib import Path
 
+import pytest
+from Crypto.Cipher import AES
 from sqlcipher3 import dbapi2
 
 from sigexport import create, files, models
+
+
+def write_encrypted_attachment(src_path: Path, plaintext: bytes) -> dict[str, str]:
+    """Build a v2 (locally encrypted) attachment on disk, as Signal stores it."""
+    cipher_key = bytes(range(files.CIPHER_KEY_SIZE))
+    mac_key = bytes(range(files.MAC_KEY_SIZE))
+    iv = bytes(files.IV_SIZE)
+
+    padding = -len(plaintext) % AES.block_size
+    ciphertext = AES.new(cipher_key, AES.MODE_CBC, iv).encrypt(
+        plaintext + bytes(padding)
+    )
+    mac = hmac.new(mac_key, iv + ciphertext, hashlib.sha256).digest()
+    src_path.write_bytes(iv + ciphertext + mac)
+
+    return {
+        "localKey": base64.b64encode(cipher_key + mac_key).decode(),
+        "size": str(len(plaintext)),
+        "version": "2",
+    }
 
 
 def test_copy_attachments_sanitizes_filesystem_reserved_characters(
@@ -67,3 +92,37 @@ def test_copy_attachments_sanitizes_filesystem_reserved_characters(
 
     rendered = create.create_message(message, "Alice", False, contacts).to_md()
     assert safe_name in rendered
+
+
+PNG = b"\x89PNG\r\n\x1a\n" + b"\x00" * 64
+
+
+def test_decrypt_attachment_without_type_detection(tmp_path: Path) -> None:
+    """copy_attachments() calls this with detect_file_type defaulted to False."""
+    src_path = tmp_path / "encrypted"
+    att = write_encrypted_attachment(src_path, b"attachment data")
+    dst_path = tmp_path / "decrypted.pdf"
+
+    files.decrypt_attachment(att, src_path, dst_path)
+
+    assert dst_path.read_bytes() == b"attachment data"
+
+
+def test_decrypt_attachment_detects_extension(tmp_path: Path) -> None:
+    src_path = tmp_path / "encrypted"
+    att = write_encrypted_attachment(src_path, PNG)
+    dst_path = tmp_path / "decrypted"
+
+    files.decrypt_attachment(att, src_path, dst_path, detect_file_type=True)
+
+    assert dst_path.with_suffix(".png").read_bytes() == PNG
+
+
+def test_decrypt_attachment_rejects_undetectable_type(tmp_path: Path) -> None:
+    """Callers only catch ValueError, so an unguessable type must raise that."""
+    src_path = tmp_path / "encrypted"
+    att = write_encrypted_attachment(src_path, bytes(64))
+    dst_path = tmp_path / "decrypted"
+
+    with pytest.raises(ValueError):
+        files.decrypt_attachment(att, src_path, dst_path, detect_file_type=True)

--- a/tests/test_stickers.py
+++ b/tests/test_stickers.py
@@ -1,0 +1,85 @@
+from pathlib import Path
+
+from sigexport import create, files, models
+
+
+def make_message(sticker: dict) -> models.RawMessage:
+    return models.RawMessage(
+        conversation_id="contact",
+        id="message",
+        body="",
+        type="incoming",
+        source=None,
+        timestamp=1,
+        sent_at=None,
+        server_timestamp=None,
+        has_attachments=False,
+        attachments=[],
+        read_status=None,
+        seen_status=None,
+        call_history=None,
+        reactions=[],
+        sticker=sticker,
+        quote=None,
+    )
+
+
+CONTACTS = {
+    "contact": models.Contact(
+        id="contact",
+        serviceId="service",
+        name="Alice",
+        number="",
+        profile_name="",
+        is_group=False,
+        members=None,
+    )
+}
+
+
+def render(message: models.RawMessage) -> str:
+    return create.create_message(message, "Alice", False, CONTACTS).to_md()
+
+
+def test_missing_sticker_file_falls_back_to_emoji(tmp_path: Path) -> None:
+    """A sticker we never downloaded should not be linked as if we had."""
+    sticker = {"stickerId": 102, "packId": "pack", "packKey": "key", "emoji": "🐺"}
+    message = make_message(sticker)
+    destination = tmp_path / "export"
+    destination.mkdir()
+
+    files.check_stickers_existence({"contact": [message]}, CONTACTS, destination)
+
+    assert sticker["extension"] is None
+    rendered = render(message)
+    assert "(( 🐺 ))" in rendered
+    assert "exported_stickers" not in rendered
+
+
+def test_present_sticker_file_is_linked(tmp_path: Path) -> None:
+    sticker = {"stickerId": 102, "packId": "pack", "packKey": "key", "emoji": "🐺"}
+    message = make_message(sticker)
+    destination = tmp_path / "export"
+    (destination / "exported_stickers" / "pack").mkdir(parents=True)
+    (destination / "exported_stickers" / "pack" / "102.webp").write_bytes(b"sticker")
+
+    files.check_stickers_existence({"contact": [message]}, CONTACTS, destination)
+
+    assert sticker["extension"] == "webp"
+    assert "[🐺](../exported_stickers/pack/102.webp)" in render(message)
+
+
+def test_sticker_without_emoji_still_gets_a_label() -> None:
+    """Signal omits the emoji entirely for stickers that have none assigned."""
+    message = make_message({"stickerId": 102, "packId": "pack", "packKey": "key"})
+    assert "(( sticker ))" in render(message)
+
+
+def test_sticker_survives_skipped_sticker_export() -> None:
+    """Without --stickers nothing backfills the extension, so don't invent a link."""
+    message = make_message(
+        {"stickerId": 102, "packId": "pack", "packKey": "key", "emoji": "🐺"}
+    )
+    rendered = render(message)
+    assert "(( 🐺 ))" in rendered
+    assert "exported_stickers" not in rendered


### PR DESCRIPTION
Two unrelated fixes that I hit back to back exporting a real history. Happy to split them if you'd rather.

## 1. `UnboundLocalError` on every v2 attachment (regression on `main`)

`decrypt_attachment()` only binds `dst_path_str` inside the `if detect_file_type:` branch, but `open()` uses it unconditionally. `copy_attachments()` calls it with the default `detect_file_type=False`, so any attachment with `version >= 2` that decrypts successfully crashes the run:

```
UnboundLocalError: cannot access local variable 'dst_path_str' where it is not associated with a value
```

Introduced in f436fde. The original code rebound the `dst_path` parameter to a `str`, which was type-sloppy but worked; renaming it to `dst_path_str` for the type checker moved the binding inside the branch without moving the use. This is after the v3.8.4 tag, so it only affects people installing from `main`, but for them it's a hard blocker on attachment export.

While in there: `filetype.guess_extension()` returns `None` rather than raising when it can't identify the data, so `"." + ext` raised `TypeError`. Neither call site catches that (both only catch `ValueError`), so an unrecognised sticker format would take down the whole run rather than skipping one file. Now raises `ValueError`.

## 2. Stickers that were never exported are linked as if they were

`Sticker.get_path()` treats any truthy `extension` as a real file on disk, but `"unknown"` is the sentinel `check_stickers_existence()` writes when a sticker isn't present locally. So a skipped sticker renders as:

```
[🐺](../exported_stickers/<packId>/<stickerId>.unknown)
```

a link to a file that never exists, rather than falling back to the `(( 🐺 ))` form the `else` branch of `get_path()` was clearly meant to produce. Same in the HTML output, where it becomes a broken `<img src>`.

This also affects `--no-stickers`, where `check_stickers_existence()` never runs and nothing backfills the extension at all. Since #212 defaults it to `"unknown"`, *every* sticker in the export links into an `exported_stickers/` directory that was never created.

Using `None` in both places lets `get_path()` fall through correctly, and matches the declared type `extension: str | None = None`.

Smaller, related: Signal omits the `emoji` key entirely for stickers with no emoji assigned (I have exactly one such message in ~84 sticker messages, which is how I found this). #212 correctly stops that being a `KeyError`, but `.get("emoji", "")` then renders `[](../path)`, a zero-length markdown link that some renderers drop entirely. Added a `Sticker.label` property falling back to `"sticker"`, used in both the markdown and HTML paths.

## Tests

`tests/test_stickers.py` covers the missing-file fallback, the happy path, the no-emoji case, and the `--no-stickers` case. `tests/test_files.py` gains three cases around `decrypt_attachment()`, building a real v2 encrypted attachment rather than mocking.

Five of the nine fail on current `main`. `ruff check`, `ruff format --check` and `ty check` are clean.