### PR TITLE
Restyle HTML export with light/dark theming

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ An export for a group conversation looks as follows:
 
 Images are attached inline with `![name](path)` while other attachments (voice notes, videos, documents) are included as links like `[name](path)` so a click will take you to the file.
 
-This is converted to HTML at the end so it can be opened with any web browser. The stylesheet `.css` is still very basic but I'll get to it sooner or later.
+This is converted to HTML at the end so it can be opened with any web browser. The HTML export is styled as a chat view with grouped messages, day dividers, reactions, and an image lightbox. It follows your browser/OS light or dark preference by default, and a switcher in the top bar lets you pin light or dark (remembered per browser).
 
 ## 🐧 Installation
 

--- a/sigexport/chat.js
+++ b/sigexport/chat.js
@@ -1,0 +1,143 @@
+/* Theme switching and keyboard navigation for signal-export HTML output.
+   Loaded from <head> so the stored theme is applied before the first paint. */
+(function () {
+    "use strict";
+
+    var root = document.documentElement;
+    var KEY = "sigexport-theme";
+
+    root.classList.add("js");
+
+    function stored() {
+        try {
+            return localStorage.getItem(KEY);
+        } catch (e) {
+            /* file:// with storage disabled, or private mode */
+            return null;
+        }
+    }
+
+    function remember(theme) {
+        try {
+            if (theme === "auto") {
+                localStorage.removeItem(KEY);
+            } else {
+                localStorage.setItem(KEY, theme);
+            }
+        } catch (e) {
+            /* not fatal, the theme just will not stick */
+        }
+    }
+
+    function apply(theme) {
+        if (theme === "light" || theme === "dark") {
+            root.setAttribute("data-theme", theme);
+        } else {
+            theme = "auto";
+            root.removeAttribute("data-theme");
+        }
+        var buttons = document.querySelectorAll("[data-theme-choice]");
+        for (var i = 0; i < buttons.length; i++) {
+            buttons[i].setAttribute(
+                "aria-pressed",
+                buttons[i].dataset.themeChoice === theme ? "true" : "false"
+            );
+        }
+    }
+
+    /* Before paint: no flash of the wrong theme. */
+    apply(stored());
+
+    function currentPage() {
+        var m = /^#pg(\d+)$/.exec(location.hash);
+        return m ? parseInt(m[1], 10) : 0;
+    }
+
+    function closeModals() {
+        var open = document.querySelectorAll(".modal-state:checked");
+        for (var i = 0; i < open.length; i++) {
+            open[i].checked = false;
+        }
+        return open.length > 0;
+    }
+
+    function isField(el) {
+        if (!el) return false;
+        var tag = el.tagName;
+        return tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT";
+    }
+
+    function jumpTo(input) {
+        var max = parseInt(input.max, 10) || 1;
+        var n = parseInt(input.value, 10);
+        if (isNaN(n)) {
+            input.value = currentPage() + 1;
+            return;
+        }
+        n = Math.min(Math.max(n, 1), max);
+        input.value = n;
+        location.hash = "pg" + (n - 1);
+    }
+
+    function onKey(e) {
+        if (e.defaultPrevented || e.altKey || e.ctrlKey || e.metaKey) return;
+        if (e.key === "Escape") {
+            if (isField(e.target) && e.target.blur) e.target.blur();
+            closeModals();
+            return;
+        }
+        /* let the page-number field handle its own keys */
+        if (isField(e.target)) return;
+        if (e.key !== "ArrowLeft" && e.key !== "ArrowRight") return;
+
+        var last = parseInt(document.body.dataset.lastPage, 10) || 0;
+        var page = currentPage();
+        var next = e.key === "ArrowLeft" ? page - 1 : page + 1;
+        if (next < 0 || next > last) return;
+        location.hash = "pg" + next;
+        e.preventDefault();
+    }
+
+    function ready() {
+        apply(stored());
+
+        document.addEventListener("click", function (e) {
+            if (!e.target || !e.target.closest) return;
+            var button = e.target.closest("[data-theme-choice]");
+            if (!button) return;
+            var theme = button.dataset.themeChoice;
+            remember(theme);
+            apply(theme);
+        });
+
+        document.addEventListener("keydown", onKey);
+
+        /* Enable the page-number jump field (readonly until JS is here). */
+        var jumps = document.querySelectorAll(".pagejump");
+        for (var j = 0; j < jumps.length; j++) {
+            jumps[j].removeAttribute("readonly");
+            jumps[j].addEventListener("change", function () {
+                jumpTo(this);
+            });
+            jumps[j].addEventListener("keydown", function (e) {
+                if (e.key === "Enter") {
+                    e.preventDefault();
+                    jumpTo(this);
+                }
+            });
+        }
+
+        /* Browsers without :has() cannot show the first page unaided. */
+        var hasSupport =
+            window.CSS && CSS.supports && CSS.supports("selector(:has(*))");
+        if (!hasSupport && !location.hash) {
+            location.hash = "pg0";
+        }
+    }
+
+    if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", ready);
+    } else {
+        ready();
+    }
+})();

--- a/sigexport/create.py
+++ b/sigexport/create.py
@@ -64,6 +64,26 @@ def _format_call(call_history: dict[str, Any] | None) -> str:
         return "Incoming call" if call_history.get("wasIncoming") else "Outgoing call"
 
 
+def _describe_quote(quote: dict[str, Any] | None) -> str:
+    """Short label for a reply whose quoted message has no text of its own."""
+    if not isinstance(quote, dict):
+        return ""
+    attachments = quote.get("attachments") or []
+    for att in attachments:
+        if not isinstance(att, dict):
+            continue
+        content_type = (att.get("contentType") or "").lower()
+        if content_type.startswith("image/"):
+            return "Photo"
+        if content_type.startswith("video/"):
+            return "Video"
+        if content_type.startswith("audio/"):
+            return "Voice message"
+        name = att.get("fileName")
+        return str(name) if name else "Attachment"
+    return ""
+
+
 def create_message(
     msg: models.RawMessage,
     name: str,  # only used for debug logging
@@ -118,6 +138,13 @@ def create_message(
         path = Path(re.sub(r"\s", "%20", str(path)))
         attachments.append(models.Attachment(name=file_name, path=str(path)))
 
+    # The message had attachments but none reached the export (e.g.
+    # --no-attachments, or a newer DB that keeps them in a table we skipped).
+    # Leave a placeholder so they aren't silently dropped.
+    if not attachments and msg.has_attachments:
+        kind = "media" if msg.has_visual_media else "attachment"
+        attachments.append(models.Attachment(name="", path="", missing_kind=kind))
+
     reactions: list[models.Reaction] = []
     if msg.reactions:
         for r in msg.reactions:
@@ -142,12 +169,18 @@ def create_message(
 
     quote = ""
     if msg.quote:
+        quote_text = ""
         try:
-            quote = msg.quote["text"].rstrip("\n")
-            quote = quote.replace("\n", "\n> ")
-            quote = f"\n\n> {quote}\n\n"
-        except (AttributeError, KeyError, TypeError):
+            quote_text = (msg.quote.get("text") or "").rstrip("\n")
+        except (AttributeError, TypeError):
             pass
+        # A reply to an image/voice note has no quoted text; describe the
+        # attachment instead so it still reads as a reply.
+        if not quote_text:
+            quote_text = _describe_quote(msg.quote)
+        if quote_text:
+            quote_text = quote_text.replace("\n", "\n> ")
+            quote = f"\n\n> {quote_text}\n\n"
 
     return models.Message(
         date=date,

--- a/sigexport/create.py
+++ b/sigexport/create.py
@@ -76,8 +76,14 @@ def create_message(
         log("\t\tNo timestamp or sent_at; date set to 1970")
     log(f"\t\tDoing {name}, msg: {date}")
 
-    if msg.type == "call-history":
+    is_call = msg.type == "call-history"
+    missed_call = False
+    if is_call:
         body = _format_call(msg.call_history)
+        status = (msg.call_history or {}).get("status", "")
+        missed_call = status in ("Missed", "NotAccepted", "Declined") or any(
+            marker in body for marker in ("Missed", "unanswered", "declined")
+        )
     else:
         body = msg.body or ""
 
@@ -151,6 +157,9 @@ def create_message(
         sticker=sticker,
         reactions=reactions,
         attachments=attachments,
+        deleted=msg.deleted,
+        call=is_call,
+        missed=missed_call,
     )
 
 

--- a/sigexport/data.py
+++ b/sigexport/data.py
@@ -203,6 +203,7 @@ def fetch_data(
                 sticker=jsonLoaded.get("sticker"),
                 quote=jsonLoaded.get("quote"),
                 deleted=bool(jsonLoaded.get("deletedForEveryone")),
+                has_visual_media=bool(jsonLoaded.get("hasVisualMediaAttachments")),
             )
 
             convos[cid].append(con)

--- a/sigexport/data.py
+++ b/sigexport/data.py
@@ -202,6 +202,7 @@ def fetch_data(
                 reactions=jsonLoaded.get("reactions", []),
                 sticker=jsonLoaded.get("sticker"),
                 quote=jsonLoaded.get("quote"),
+                deleted=bool(jsonLoaded.get("deletedForEveryone")),
             )
 
             convos[cid].append(con)

--- a/sigexport/html.py
+++ b/sigexport/html.py
@@ -23,13 +23,14 @@ GROUP_WINDOW = timedelta(minutes=5)
 # Markdown emitted (e.g. a trailing </p>) into the href (see #225)
 URL_PATTERN = re.compile(r"(https{0,1}://[^\s<]*)")
 
-# label and icon for an attachment we couldn't include in the export
-MISSING_KINDS = (
-    (models.is_image, "Image not exported", "\U0001f5bc️"),  # framed picture
-    (models.is_audio, "Audio not exported", "\U0001f50a"),  # speaker
-    (models.is_video, "Video not exported", "\U0001f3ac"),  # clapper board
-)
-MISSING_DEFAULT = ("Attachment not exported", "\U0001f4ce")  # paperclip
+# label and icon for each kind of attachment we couldn't include in the export
+MISSING_LABELS = {
+    "image": ("Image not exported", "\U0001f5bc️"),  # framed picture
+    "audio": ("Audio not exported", "\U0001f50a"),  # speaker
+    "video": ("Video not exported", "\U0001f3ac"),  # clapper board
+    "media": ("Media not exported", "\U0001f5bc️"),  # framed picture
+    "attachment": ("Attachment not exported", "\U0001f4ce"),  # paperclip
+}
 
 
 def _exported(media_dir: Path | None, path: str) -> bool:
@@ -42,13 +43,19 @@ def _exported(media_dir: Path | None, path: str) -> bool:
     return (media_dir / unquote(path)).exists()
 
 
-def _missing_attachment(path: str) -> str:
+def _kind_from_path(path: str) -> str:
+    if models.is_image(path):
+        return "image"
+    if models.is_audio(path):
+        return "audio"
+    if models.is_video(path):
+        return "video"
+    return "attachment"
+
+
+def _missing_attachment(kind: str) -> str:
     """Placeholder for an attachment that isn't present in the export."""
-    label, icon = MISSING_DEFAULT
-    for matches, kind_label, kind_icon in MISSING_KINDS:
-        if matches(path):
-            label, icon = kind_label, kind_icon
-            break
+    label, icon = MISSING_LABELS.get(kind, MISSING_LABELS["attachment"])
     return templates.attachment_missing.format(icon=icon, label=label)
 
 
@@ -102,8 +109,10 @@ def make_body(msg: models.Message, fid: str, media_dir: Path | None) -> str:
         path = att.path
         src = f"./{path}"
         alt = escape(att.name, quote=True)
-        if not _exported(media_dir, path):
-            temp = _missing_attachment(path)
+        if att.missing_kind is not None:
+            temp = _missing_attachment(att.missing_kind)
+        elif not _exported(media_dir, path):
+            temp = _missing_attachment(_kind_from_path(path))
         elif models.is_image(path):
             temp = templates.figure.format(fid=f"{fid}-{i}", src=src, alt=alt)
         elif models.is_audio(path):

--- a/sigexport/html.py
+++ b/sigexport/html.py
@@ -5,6 +5,7 @@ from datetime import date as date_type
 from datetime import timedelta
 from html import escape
 from pathlib import Path
+from urllib.parse import unquote
 
 import markdown
 from bs4 import BeautifulSoup
@@ -21,6 +22,34 @@ GROUP_WINDOW = timedelta(minutes=5)
 # body is already HTML here, so stop at '<' to avoid swallowing the tags
 # Markdown emitted (e.g. a trailing </p>) into the href (see #225)
 URL_PATTERN = re.compile(r"(https{0,1}://[^\s<]*)")
+
+# label and icon for an attachment we couldn't include in the export
+MISSING_KINDS = (
+    (models.is_image, "Image not exported", "\U0001f5bc️"),  # framed picture
+    (models.is_audio, "Audio not exported", "\U0001f50a"),  # speaker
+    (models.is_video, "Video not exported", "\U0001f3ac"),  # clapper board
+)
+MISSING_DEFAULT = ("Attachment not exported", "\U0001f4ce")  # paperclip
+
+
+def _exported(media_dir: Path | None, path: str) -> bool:
+    """Whether the attachment file actually landed in the export directory.
+
+    When media_dir is None (e.g. in tests) we optimistically assume it did.
+    """
+    if media_dir is None:
+        return True
+    return (media_dir / unquote(path)).exists()
+
+
+def _missing_attachment(path: str) -> str:
+    """Placeholder for an attachment that isn't present in the export."""
+    label, icon = MISSING_DEFAULT
+    for matches, kind_label, kind_icon in MISSING_KINDS:
+        if matches(path):
+            label, icon = kind_label, kind_icon
+            break
+    return templates.attachment_missing.format(icon=icon, label=label)
 
 
 def prep_html(dest: Path) -> None:
@@ -58,7 +87,7 @@ def make_pager(page_num: int, last_page: int) -> str:
     )
 
 
-def make_body(msg: models.Message, fid: str) -> str:
+def make_body(msg: models.Message, fid: str, media_dir: Path | None) -> str:
     """Render the message body, with attachments and stickers appended."""
     body = msg.body
     try:
@@ -73,7 +102,9 @@ def make_body(msg: models.Message, fid: str) -> str:
         path = att.path
         src = f"./{path}"
         alt = escape(att.name, quote=True)
-        if models.is_image(path):
+        if not _exported(media_dir, path):
+            temp = _missing_attachment(path)
+        elif models.is_image(path):
             temp = templates.figure.format(fid=f"{fid}-{i}", src=src, alt=alt)
         elif models.is_audio(path):
             temp = templates.audio.format(src=src)
@@ -97,8 +128,23 @@ def make_body(msg: models.Message, fid: str) -> str:
     return str(soup)
 
 
-def make_message(msg: models.Message, fid: str, show_meta: bool) -> str:
-    """Render a single message bubble."""
+def make_message(
+    msg: models.Message, fid: str, show_meta: bool, media_dir: Path | None
+) -> str:
+    """Render a single message bubble (or a centred event line for calls)."""
+    # Calls are events, not chat bubbles.
+    if msg.call:
+        cls = "call missed" if msg.missed else "call"
+        icon = "\U0001f4f9" if "video" in msg.body.lower() else "\U0001f4de"
+        return templates.event.format(
+            cls=cls,
+            icon=icon,
+            text=escape(msg.body.strip()),
+            iso=msg.date.isoformat(),
+            date=msg.date.strftime("%Y-%m-%d %H:%M:%S"),
+            time=msg.date.time().replace(microsecond=0).isoformat(),
+        )
+
     meta = ""
     if show_meta:
         meta = templates.meta.format(
@@ -106,6 +152,20 @@ def make_message(msg: models.Message, fid: str, show_meta: bool) -> str:
             iso=msg.date.isoformat(),
             date=msg.date.strftime("%Y-%m-%d %H:%M:%S"),
             time=msg.date.time().replace(microsecond=0).isoformat(),
+        )
+
+    cl = "msg me" if msg.sender == "Me" else "msg"
+    if not show_meta:
+        cl += " cont"
+
+    # A message deleted for everyone has no body/attachments to show.
+    if msg.deleted:
+        return templates.message.format(
+            cl=cl + " deleted",
+            meta=meta,
+            quote="",
+            body=templates.deleted,
+            reactions="",
         )
 
     quote = ""
@@ -123,23 +183,26 @@ def make_message(msg: models.Message, fid: str, show_meta: bool) -> str:
         )
         reactions = templates.reactions.format(chips=chips)
 
-    cl = "msg me" if msg.sender == "Me" else "msg"
-    if not show_meta:
-        cl += " cont"
-
     return templates.message.format(
         cl=cl,
         meta=meta,
         quote=quote,
-        body=make_body(msg, fid),
+        body=make_body(msg, fid, media_dir),
         reactions=reactions,
     )
 
 
 def create_html(
-    name: str, messages: list[models.Message], msgs_per_page: int = 100
+    name: str,
+    messages: list[models.Message],
+    msgs_per_page: int = 100,
+    media_dir: Path | None = None,
 ) -> str:
-    """Create HTML version from Markdown input."""
+    """Create HTML version from Markdown input.
+
+    ``media_dir`` is the chat's output directory; when given, attachments whose
+    files aren't present there are rendered as "not exported" placeholders.
+    """
 
     log(f"\tDoing html for {name}")
     total_pages = max(1, -(-len(messages) // msgs_per_page))
@@ -160,11 +223,15 @@ def create_html(
 
             grouped = (
                 prev is not None
+                and not msg.call
                 and prev.sender == msg.sender
                 and msg.date - prev.date < GROUP_WINDOW
             )
-            content += make_message(msg, f"m{page_num}-{i}", show_meta=not grouped)
-            prev = msg
+            content += make_message(
+                msg, f"m{page_num}-{i}", show_meta=not grouped, media_dir=media_dir
+            )
+            # a call is an event, not a bubble, so don't group the next msg onto it
+            prev = None if msg.call else msg
 
         pages.append(
             templates.page.format(

--- a/sigexport/html.py
+++ b/sigexport/html.py
@@ -1,6 +1,9 @@
 import os
 import re
 import shutil
+from datetime import date as date_type
+from datetime import timedelta
+from html import escape
 from pathlib import Path
 
 import markdown
@@ -10,19 +13,127 @@ from typer import secho
 from sigexport import models, templates
 from sigexport.logging import log
 
+ASSETS = ("style.css", "chat.js")
+
+# messages closer together than this from the same sender get grouped
+GROUP_WINDOW = timedelta(minutes=5)
+
+# body is already HTML here, so stop at '<' to avoid swallowing the tags
+# Markdown emitted (e.g. a trailing </p>) into the href (see #225)
+URL_PATTERN = re.compile(r"(https{0,1}://[^\s<]*)")
+
 
 def prep_html(dest: Path) -> None:
-    """Prepare CSS etc"""
+    """Copy the stylesheet and script to the export root."""
     root = Path(__file__).resolve().parents[0]
-    css_source = root / "style.css"
-    css_dest = dest / "style.css"
-    if os.path.isfile(css_source):
-        shutil.copy2(css_source, css_dest)
-    else:
-        secho(
-            f"Stylesheet ({css_source}) not found."
-            f"You might want to install one manually at {css_dest}."
+    for asset in ASSETS:
+        source = root / asset
+        target = dest / asset
+        if os.path.isfile(source):
+            shutil.copy2(source, target)
+        else:
+            secho(
+                f"Asset ({source}) not found."
+                f"You might want to install one manually at {target}."
+            )
+
+
+def make_pager(page_num: int, last_page: int) -> str:
+    """Build the pagination controls for one page."""
+    if last_page == 0:
+        return ""
+
+    def link(target: int, symbol: str, label: str) -> str:
+        if target == page_num:
+            return templates.pager_disabled.format(symbol=symbol)
+        return templates.pager_link.format(page_num=target, symbol=symbol, label=label)
+
+    return templates.pager.format(
+        first=link(0, "&laquo;", "First page"),
+        prev=link(max(page_num - 1, 0), "&lsaquo;", "Previous page"),
+        page_num=page_num + 1,
+        total_pages=last_page + 1,
+        next=link(min(page_num + 1, last_page), "&rsaquo;", "Next page"),
+        last=link(last_page, "&raquo;", "Last page"),
+    )
+
+
+def make_body(msg: models.Message, fid: str) -> str:
+    """Render the message body, with attachments and stickers appended."""
+    body = msg.body
+    try:
+        body = markdown.Markdown().convert(body)
+    except RecursionError:
+        log(f"Maximum recursion on message {body}, not converted")
+
+    body = re.sub(URL_PATTERN, r"<a href='\1' target='_blank'>\1</a> ", body)
+
+    soup = BeautifulSoup(body, "html.parser")
+    for i, att in enumerate(msg.attachments):
+        path = att.path
+        src = f"./{path}"
+        alt = escape(att.name, quote=True)
+        if models.is_image(path):
+            temp = templates.figure.format(fid=f"{fid}-{i}", src=src, alt=alt)
+        elif models.is_audio(path):
+            temp = templates.audio.format(src=src)
+        elif models.is_video(path):
+            temp = templates.video.format(src=src)
+        else:
+            temp = templates.file_link.format(src=src, name=alt)
+        soup.append(BeautifulSoup(temp, "html.parser"))
+
+    if msg.sticker:
+        label = escape(msg.sticker.label, quote=True)
+        sticker_path = msg.sticker.get_path()
+        if sticker_path:
+            temp = templates.figure.format(
+                fid=f"{fid}-sticker", src=f"../{sticker_path}", alt=label
+            )
+        else:
+            temp = f"(( {label} ))"
+        soup.append(BeautifulSoup(temp, "html.parser"))
+
+    return str(soup)
+
+
+def make_message(msg: models.Message, fid: str, show_meta: bool) -> str:
+    """Render a single message bubble."""
+    meta = ""
+    if show_meta:
+        meta = templates.meta.format(
+            sender=escape(msg.sender),
+            iso=msg.date.isoformat(),
+            date=msg.date.strftime("%Y-%m-%d %H:%M:%S"),
+            time=msg.date.time().replace(microsecond=0).isoformat(),
         )
+
+    quote = ""
+    quote_text = msg.quote.replace(">", "").strip()
+    if quote_text:
+        quote = templates.quote.format(text=escape(quote_text).replace("\n", "<br>"))
+
+    reactions = ""
+    if msg.reactions:
+        chips = "".join(
+            templates.reaction.format(
+                emoji=escape(r.emoji or ""), name=escape(r.name or "Unknown")
+            )
+            for r in msg.reactions
+        )
+        reactions = templates.reactions.format(chips=chips)
+
+    cl = "msg me" if msg.sender == "Me" else "msg"
+    if not show_meta:
+        cl += " cont"
+
+    return templates.message.format(
+        cl=cl,
+        meta=meta,
+        quote=quote,
+        body=make_body(msg, fid),
+        reactions=reactions,
+    )
 
 
 def create_html(
@@ -31,97 +142,42 @@ def create_html(
     """Create HTML version from Markdown input."""
 
     log(f"\tDoing html for {name}")
-    # touch first
-    ht_content = ""
-    last_page = int(len(messages) / msgs_per_page)
+    total_pages = max(1, -(-len(messages) // msgs_per_page))
+    last_page = total_pages - 1
 
-    page_num = 0
-    for i, msg in enumerate(messages):
-        if i % msgs_per_page == 0:
-            nav = "\n"
-            if i > 0:
-                nav += "</div>"
-            nav += f"<div class=page id=pg{page_num}>"
-            nav += "<nav>"
-            nav += "<div class=prev>"
-            if page_num != 0:
-                nav += f"<a href=#pg{page_num - 1}>PREV</a>"
-            else:
-                nav += "PREV"
-            nav += "</div><div class=next>"
-            if page_num != last_page:
-                nav += f"<a href=#pg{page_num + 1}>NEXT</a>"
-            else:
-                nav += "NEXT"
-            nav += "</div></nav>\n"
-            ht_content += nav
-            page_num += 1
+    pages = []
+    for page_num in range(total_pages):
+        chunk = messages[page_num * msgs_per_page : (page_num + 1) * msgs_per_page]
+        content = ""
+        prev: models.Message | None = None
+        prev_day: date_type | None = None
+        for i, msg in enumerate(chunk):
+            day = msg.date.date()
+            if day != prev_day:
+                content += templates.day.format(date=day.isoformat())
+                prev = None  # always show the sender after a day break
+            prev_day = day
 
-        sender = msg.sender
-        date = msg.date.date().isoformat()
-        time = msg.date.time().replace(microsecond=0).isoformat()
+            grouped = (
+                prev is not None
+                and prev.sender == msg.sender
+                and msg.date - prev.date < GROUP_WINDOW
+            )
+            content += make_message(msg, f"m{page_num}-{i}", show_meta=not grouped)
+            prev = msg
 
-        reactions = " ".join(f"{r.name}: {r.emoji}" for r in msg.reactions)
-        quote = ""
-        if msg.quote:
-            quote = f"<div class=quote>{msg.quote.replace('>', '')}</div>"
-
-        body = msg.body
-        try:
-            body = markdown.Markdown().convert(body)
-        except RecursionError:
-            log(f"Maximum recursion on message {body}, not converted")
-
-        # links
-        # body is already HTML at this point, so stop at '<' to avoid swallowing
-        # the tags Markdown emitted (e.g. a trailing </p>) into the href
-        p = re.compile(r"(https{0,1}://[^\s<]*)")
-        a_template = r"<a href='\1' target='_blank'>\1</a> "
-        body = re.sub(p, a_template, body)
-
-        soup = BeautifulSoup(body, "html.parser")
-        # attachments
-        for att in msg.attachments:
-            path = att.path
-            src = f"./{path}"
-            if models.is_image(path):
-                temp = templates.figure.format(src=src, alt=att.name)
-            elif models.is_audio(path):
-                temp = templates.audio.format(src=src)
-            elif models.is_video(path):
-                temp = templates.video.format(src=src)
-            else:
-                temp = None
-            if temp:
-                soup.append(BeautifulSoup(temp, "html.parser"))
-
-        # sticker
-        if msg.sticker:
-            sticker_path = msg.sticker.get_path()
-
-            if sticker_path:
-                src = f"../{sticker_path}"
-                temp = templates.figure.format(src=src, alt=msg.sticker.label)
-            else:
-                temp = "(( " + msg.sticker.label + " ))"
-
-            if temp:
-                soup.append(BeautifulSoup(temp, "html.parser"))
-
-        cl = "msg me" if sender == "Me" else "msg"
-        ht_content += templates.message.format(
-            cl=cl,
-            date=date,
-            time=time,
-            sender=sender,
-            quote=quote,
-            body=soup,
-            reactions=reactions,
+        pages.append(
+            templates.page.format(
+                page_num=page_num,
+                pager=make_pager(page_num, last_page),
+                content=content,
+            )
         )
+
     ht_text = templates.html.format(
-        name=name,
+        name=escape(name),
         last_page=last_page,
-        content=ht_content,
+        content="".join(pages),
     )
     ht_text = BeautifulSoup(ht_text, "html.parser").prettify()
     ht_text = re.compile(r"^(\s*)", re.MULTILINE).sub(r"\1\1\1\1", ht_text)

--- a/sigexport/main.py
+++ b/sigexport/main.py
@@ -219,7 +219,10 @@ def main(
                     print(msg.dict_str(), file=js_f)
             if ht_f:
                 ht = html.create_html(
-                    name=name, messages=messages, msgs_per_page=paginate
+                    name=name,
+                    messages=messages,
+                    msgs_per_page=paginate,
+                    media_dir=dest / name,
                 )
                 print(ht, file=ht_f)
         finally:

--- a/sigexport/models.py
+++ b/sigexport/models.py
@@ -36,6 +36,8 @@ class RawMessage:
     sticker: dict[str, Any] | None
     quote: dict[str, Any] | None
 
+    deleted: bool = False
+
     def get_ts(self: RawMessage) -> int:
         if self.sent_at and self.server_timestamp:
             if self.server_timestamp < self.sent_at:
@@ -159,9 +161,14 @@ class Message:
     sticker: Sticker | None
     reactions: list[Reaction]
     attachments: list[Attachment]
+    deleted: bool = False
+    call: bool = False
+    missed: bool = False
 
     def to_md(self: Message) -> str:
         date_str = self.date.strftime("%Y-%m-%d %H:%M:%S")
+        if self.deleted:
+            return f"[{date_str}] {self.sender}: (This message was deleted)\n"
         body = self.body
 
         if len(self.reactions) > 0:

--- a/sigexport/models.py
+++ b/sigexport/models.py
@@ -37,6 +37,7 @@ class RawMessage:
     quote: dict[str, Any] | None
 
     deleted: bool = False
+    has_visual_media: bool = False
 
     def get_ts(self: RawMessage) -> int:
         if self.sent_at and self.server_timestamp:
@@ -150,6 +151,9 @@ def is_video(p: str) -> bool:
 class Attachment:
     name: str
     path: str
+    # set when the attachment existed but wasn't included in the export
+    # (e.g. --no-attachments, missing source file, failed decrypt)
+    missing_kind: str | None = None
 
 
 @dataclass
@@ -183,6 +187,9 @@ class Message:
                 body = body + "\n(( " + self.sticker.label + " ))"
 
         for att in self.attachments:
+            if att.missing_kind is not None:
+                body += f"({att.missing_kind} not exported)  "
+                continue
             if is_image(att.path):
                 body += "!"
             body += f"[{att.name}](./{att.path})  "

--- a/sigexport/style.css
+++ b/sigexport/style.css
@@ -251,6 +251,26 @@ body:not(:has(.page:target)) main > .page:first-child {
     background-color: var(--border);
 }
 
+/* calls (and other non-message events) render centred, not as bubbles */
+.event {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.4rem;
+    margin: 0.6rem 0;
+    font-size: 0.8rem;
+    color: var(--muted);
+}
+
+.event .event-time {
+    opacity: 0.7;
+    font-variant-numeric: tabular-nums;
+}
+
+.event.missed {
+    color: light-dark(#c0342b, #f2857c);
+}
+
 .msg {
     width: fit-content;
     max-width: min(70ch, 80%);
@@ -306,6 +326,25 @@ body:not(:has(.page:target)) main > .page:first-child {
 
 .body > p:last-child {
     margin-bottom: 0;
+}
+
+/* deleted-for-everyone placeholder */
+.msg.deleted {
+    background-color: transparent;
+    border-style: dashed;
+    box-shadow: none;
+}
+
+.msg.deleted .body {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    color: var(--muted);
+}
+
+.msg.deleted .body::before {
+    content: "\1F6AB"; /* no-entry sign */
+    font-style: normal;
 }
 
 .quote {
@@ -371,6 +410,13 @@ audio {
     border-radius: 8px;
     background-color: var(--surface-2);
     font-size: 0.85rem;
+}
+
+.file.missing {
+    border-style: dashed;
+    background-color: transparent;
+    color: var(--muted);
+    font-style: italic;
 }
 
 .modal {

--- a/sigexport/style.css
+++ b/sigexport/style.css
@@ -1,65 +1,55 @@
+/* signal-export stylesheet.
+   Colours are defined once with light-dark(); the theme switcher just flips
+   color-scheme on <html>, and "auto" means we follow the browser/OS setting. */
+
+:root {
+    color-scheme: light dark;
+
+    --bg: light-dark(#f2f3f5, #15171a);
+    --surface: light-dark(#ffffff, #1e2126);
+    --surface-2: light-dark(#e9ebef, #262a30);
+    --text: light-dark(#181a1d, #e4e7ea);
+    --muted: light-dark(#5f6672, #99a1ac);
+    --border: light-dark(#dfe2e7, #30353c);
+    --accent: light-dark(#2b6cee, #85aaff);
+
+    --bubble-in: light-dark(#ffffff, #22262c);
+    --bubble-in-border: light-dark(#e2e5ea, #30353c);
+    --bubble-out: light-dark(#dbe8ff, #21395f);
+    --bubble-out-border: light-dark(#c5d9fb, #2c4b7c);
+
+    --shadow: 0 1px 2px light-dark(rgba(16, 20, 26, 0.09), rgba(0, 0, 0, 0.45));
+    --radius: 14px;
+
+    --font: system-ui, -apple-system, "Segoe UI", Roboto, Carlito, Calibri,
+        sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Noto Color Emoji";
+}
+
+/* Manual overrides from the theme switcher. */
+:root[data-theme="light"] {
+    color-scheme: light;
+}
+
+:root[data-theme="dark"] {
+    color-scheme: dark;
+}
+
 * {
     box-sizing: border-box;
 }
 
-html {
-    background-color: #F6F6F6;
-}
-
 body {
-    color: rgb(73, 78, 82);
-    font-family: Carlito, Calibri, sans-serif;
+    background-color: var(--bg);
+    color: var(--text);
+    font-family: var(--font);
     line-height: 1.5;
     margin: 0;
-}
-
-.first, .last, .next, .prev {
-    position: fixed;
-    left: 0;
-    font-size: 3em;
-    margin: 20px;
-}
-
-.first {
-    top: 0;
-}
-
-.prev {
-    top: 20%;
-}
-
-.next {
-    bottom: 20%;
-}
-
-.last {
-    bottom: 0;
-}
-
-.page {
-    display: none;
-    padding: 20px;
-}
-
-.page:target {
-    display: block;
-}
-
-.msg {
-    width: 70ch;
-    border-radius: 5px;
-    padding: 0.8rem 0.8rem 2rem 0.8rem;
-    margin-left: 150px;
-    background-color: #cecace;
-}
-
-.msg.me {
-    margin-left: 450px;
-    background-color: #bfd9d7;
+    /* room for the floating pager */
+    padding-bottom: 5rem;
 }
 
 a {
-    color: rgb(52, 105, 160);
+    color: var(--accent);
     text-decoration: none;
 }
 
@@ -67,64 +57,346 @@ a:hover {
     text-decoration: underline;
 }
 
-div {
-    margin-bottom: 2em;
+/* ---------- header ---------- */
+
+.topbar {
+    position: sticky;
+    top: 0;
+    z-index: 30;
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 0.6rem 1rem;
+    border-bottom: 1px solid var(--border);
+    background-color: light-dark(rgba(255, 255, 255, 0.82), rgba(21, 23, 26, 0.82));
+    backdrop-filter: blur(10px);
 }
 
-.date, .time {
-    float: right;
+.chat-title {
+    flex: 1;
+    min-width: 0;
+    margin: 0;
+    font-size: 1.05rem;
+    font-weight: 600;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
-.time {
-    clear: right;
+/* The switcher does nothing without JS, so only show it once JS says hello.
+   Auto theming still works: it is pure CSS. */
+html:not(.js) .theme-switch {
+    display: none;
 }
 
-.sender {
-    font-weight: bold;
+.theme-switch {
+    display: inline-flex;
+    flex: none;
+    gap: 2px;
+    padding: 2px;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    background-color: var(--surface-2);
 }
 
-.body {
-    display: block;
-    margin-left: 3em;
-    word-wrap: break-word;
-}
-
-figure > label > img, video {
-    display: block;
-    width: 300px;
-}
-
-label > img {
+.theme-switch button {
+    font: inherit;
+    font-size: 0.75rem;
+    line-height: 1.6;
+    padding: 0 0.6rem;
+    border: 0;
+    border-radius: 999px;
+    background: none;
+    color: var(--muted);
     cursor: pointer;
 }
 
+.theme-switch button:hover {
+    color: var(--text);
+}
+
+.theme-switch button[aria-pressed="true"] {
+    background-color: var(--surface);
+    color: var(--text);
+    box-shadow: var(--shadow);
+}
+
+/* ---------- pages ---------- */
+
+main {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 1rem;
+}
+
+.page {
+    display: none;
+}
+
+.page:target {
+    display: block;
+}
+
+/* No hash yet (fresh open, no JS): show the first page. */
+body:not(:has(.page:target)) main > .page:first-child {
+    display: block;
+}
+
+.pager {
+    position: fixed;
+    left: 50%;
+    bottom: 1rem;
+    z-index: 20;
+    transform: translateX(-50%);
+    display: flex;
+    align-items: center;
+    gap: 0.15rem;
+    padding: 0.25rem;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    background-color: var(--surface);
+    box-shadow: var(--shadow);
+}
+
+.pager a,
+.pager span.step {
+    display: block;
+    min-width: 2rem;
+    padding: 0.1rem 0.4rem;
+    border-radius: 999px;
+    text-align: center;
+    font-size: 1.1rem;
+    line-height: 1.5;
+}
+
+.pager a:hover {
+    background-color: var(--surface-2);
+    text-decoration: none;
+}
+
+.pager span.step {
+    color: var(--muted);
+    opacity: 0.4;
+}
+
+.pager .pageno {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 0.15rem;
+    padding: 0 0.4rem;
+    font-size: 0.8rem;
+    color: var(--muted);
+    font-variant-numeric: tabular-nums;
+}
+
+.pagejump {
+    field-sizing: content;
+    min-width: 1.4rem;
+    max-width: 5rem;
+    padding: 0.05rem 0.2rem;
+    border: 1px solid transparent;
+    border-radius: 6px;
+    background: none;
+    color: inherit;
+    font: inherit;
+    text-align: center;
+    font-variant-numeric: tabular-nums;
+    /* strip the number-spinner arrows */
+    appearance: textfield;
+    -moz-appearance: textfield;
+}
+
+.pagejump::-webkit-outer-spin-button,
+.pagejump::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+}
+
+/* readonly = no JS: render as plain text, not an obvious input */
+.pagejump:read-only {
+    cursor: default;
+}
+
+.pagejump:not(:read-only) {
+    color: var(--text);
+    cursor: text;
+}
+
+.pagejump:not(:read-only):hover {
+    border-color: var(--border);
+}
+
+.pagejump:focus {
+    outline: none;
+    border-color: var(--accent);
+    color: var(--text);
+}
+
+/* ---------- messages ---------- */
+
+.day {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin: 1.5rem 0 1rem;
+    font-size: 0.75rem;
+    color: var(--muted);
+}
+
+.day::before,
+.day::after {
+    content: "";
+    flex: 1;
+    height: 1px;
+    background-color: var(--border);
+}
+
+.msg {
+    width: fit-content;
+    max-width: min(70ch, 80%);
+    margin: 0 0 0.5rem;
+    padding: 0.5rem 0.75rem;
+    border: 1px solid var(--bubble-in-border);
+    border-radius: var(--radius);
+    background-color: var(--bubble-in);
+    box-shadow: var(--shadow);
+}
+
+.msg.me {
+    margin-left: auto;
+    border-color: var(--bubble-out-border);
+    background-color: var(--bubble-out);
+}
+
+/* Follow-on message from the same sender. */
+.msg.cont {
+    margin-top: -0.25rem;
+}
+
+.meta {
+    display: flex;
+    align-items: baseline;
+    gap: 0.5rem;
+    margin-bottom: 0.15rem;
+    font-size: 0.78rem;
+}
+
+.sender {
+    font-weight: 600;
+    color: var(--accent);
+}
+
+.msg.me .sender {
+    color: var(--muted);
+}
+
+.time {
+    color: var(--muted);
+    font-variant-numeric: tabular-nums;
+}
+
+.body {
+    word-wrap: break-word;
+    overflow-wrap: anywhere;
+}
+
+.body > p:first-child {
+    margin-top: 0;
+}
+
+.body > p:last-child {
+    margin-bottom: 0;
+}
+
+.quote {
+    margin: 0 0 0.4rem;
+    padding: 0.3rem 0.6rem;
+    border-left: 3px solid var(--accent);
+    border-radius: 4px;
+    background-color: color-mix(in srgb, var(--accent) 10%, transparent);
+    font-size: 0.92em;
+    color: var(--muted);
+}
+
+.reactions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+    margin-top: 0.4rem;
+}
+
+.reaction {
+    padding: 0 0.45rem;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    background-color: var(--surface-2);
+    font-size: 0.75rem;
+    color: var(--muted);
+}
+
+.reaction .who {
+    margin-left: 0.25rem;
+}
+
+/* ---------- attachments ---------- */
+
+figure {
+    margin: 0.4rem 0 0;
+}
+
+figure img,
+video {
+    display: block;
+    max-width: min(320px, 100%);
+    border-radius: 10px;
+}
+
+label > img {
+    cursor: zoom-in;
+}
+
+audio {
+    display: block;
+    width: min(320px, 100%);
+    margin-top: 0.4rem;
+}
+
+.file {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    margin-top: 0.4rem;
+    padding: 0.35rem 0.6rem;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background-color: var(--surface-2);
+    font-size: 0.85rem;
+}
+
 .modal {
+    position: fixed;
+    inset: 0;
+    z-index: 99;
+    background-color: rgba(0, 0, 0, 0.85);
     opacity: 0;
     visibility: hidden;
-    position: fixed;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    text-align: left;
-    background: rgba(0, 0, 0, 0.8);
-    transition: opacity .25s ease;
-    z-index: 99;
+    transition: opacity 0.2s ease;
+    cursor: zoom-out;
 }
 
 .modal-content {
-    width: 100vw;
-    height: 100vh;
+    display: grid;
+    place-items: center;
+    width: 100%;
+    height: 100%;
+    padding: 2rem;
 }
 
 .modal-photo {
-    width: 70%;
-    max-height: 80%;
-    position: absolute;
-    left: 50%;
-    top: 10%;
-    margin-left: -35%;
-    object-fit: scale-down;
+    max-width: 95vw;
+    max-height: 90vh;
+    object-fit: contain;
+    border-radius: 8px;
 }
 
 .modal-state {
@@ -136,13 +408,37 @@ label > img {
     visibility: visible;
 }
 
-.reaction {
-    float: right;
+/* ---------- small screens ---------- */
+
+@media (max-width: 640px) {
+    main {
+        padding: 0.5rem;
+    }
+
+    .msg {
+        max-width: 92%;
+    }
+
+    .theme-switch button {
+        padding: 0 0.45rem;
+    }
 }
 
-.quote {
-    margin: .5rem 0 1rem 1rem;
-    background-color: #f7f6ff;
-    width: 50%;
-    padding: 1rem;
+/* ---------- print ---------- */
+
+@media print {
+    .topbar,
+    .pager {
+        display: none;
+    }
+
+    .page,
+    body:not(:has(.page:target)) main > .page:first-child {
+        display: block;
+    }
+
+    .msg {
+        break-inside: avoid;
+        box-shadow: none;
+    }
 }

--- a/sigexport/templates.py
+++ b/sigexport/templates.py
@@ -75,6 +75,23 @@ meta = """
 
 quote = "<div class=quote>{text}</div>"
 
+deleted = "<em>This message was deleted</em>"
+
+event = """
+<div class='event {cls}'>
+    <span class=event-icon aria-hidden=true>{icon}</span>
+    <span>{text}</span>
+    <time class=event-time datetime='{iso}' title='{date}'>{time}</time>
+</div>
+"""
+
+attachment_missing = """
+<div class='file missing'>
+    <span aria-hidden=true>{icon}</span>
+    <span>{label}</span>
+</div>
+"""
+
 reactions = "<div class=reactions>{chips}</div>"
 
 reaction = "<span class=reaction>{emoji}<span class=who>{name}</span></span>"

--- a/sigexport/templates.py
+++ b/sigexport/templates.py
@@ -1,62 +1,109 @@
-"""HTML templates."""
+"""HTML templates.
+
+These are used with str.format(), so any literal braces would need doubling.
+That is why the CSS and JS live in their own files (style.css, chat.js).
+"""
 
 html = """
 <!doctype html>
 <html lang='en'>
 <head>
     <meta charset='utf-8'>
+    <meta name='viewport' content='width=device-width, initial-scale=1'>
     <title>{name}</title>
     <link rel=stylesheet href='../style.css'>
+    <script src='../chat.js'></script>
 </head>
-<body>
-    <div class=first>
-        <a href=#pg0>FIRST</a>
-    </div>
-    <div class=last>
-        <a href=#pg{last_page}>LAST</a>
-    </div>
+<body data-last-page='{last_page}'>
+    <header class=topbar>
+        <h1 class=chat-title>{name}</h1>
+        <div class=theme-switch role=group aria-label='Colour theme'>
+            <button type=button data-theme-choice=auto aria-pressed=true>Auto</button>
+            <button type=button data-theme-choice=light aria-pressed=false>Light</button>
+            <button type=button data-theme-choice=dark aria-pressed=false>Dark</button>
+        </div>
+    </header>
+    <main>
     {content}
-    <script>if (!document.location.hash) document.location.hash = 'pg0'</script>
+    </main>
 </body>
 </html>
 """
 
-message = """
-<div class='{cl}'>
-    <span class=date>{date}</span>
-    <span class=time>{time}</span>
-    <span class=sender>{sender}</span>
-    {quote}
-    <span class=body>{body}</span>
-    <span class=reaction>{reactions}</span>
+page = """
+<div class=page id=pg{page_num}>
+    {pager}
+    {content}
 </div>
 """
 
+pager = """
+<nav class=pager aria-label='Pagination'>
+    {first}
+    {prev}
+    <span class=pageno>
+        <input class=pagejump type=number inputmode=numeric min=1 max={total_pages}
+            value={page_num} readonly aria-label='Jump to page'>
+        <span class=pagetotal>/ {total_pages}</span>
+    </span>
+    {next}
+    {last}
+</nav>
+"""
+
+pager_link = "<a href=#pg{page_num} title='{label}' aria-label='{label}'>{symbol}</a>"
+
+pager_disabled = "<span class=step aria-hidden=true>{symbol}</span>"
+
+day = "<div class=day>{date}</div>"
+
+message = """
+<div class='{cl}'>
+    {meta}
+    {quote}
+    <div class=body>{body}</div>
+    {reactions}
+</div>
+"""
+
+meta = """
+<div class=meta>
+    <span class=sender>{sender}</span>
+    <time class=time datetime='{iso}' title='{date}'>{time}</time>
+</div>
+"""
+
+quote = "<div class=quote>{text}</div>"
+
+reactions = "<div class=reactions>{chips}</div>"
+
+reaction = "<span class=reaction>{emoji}<span class=who>{name}</span></span>"
+
 audio = """
-<audio controls>
-    <source src="{src}" type="audio/mp4">
-</audio>
+<audio controls preload=metadata src="{src}"></audio>
 """
 
 figure = """
 <figure>
-    <label for="{alt}">
-        <img load="lazy" src="{src}" alt="{alt}">
+    <label for="{fid}">
+        <img loading="lazy" src="{src}" alt="{alt}">
     </label>
-    <input class="modal-state" id="{alt}" type="checkbox">
+    <input class="modal-state" id="{fid}" type="checkbox">
     <div class="modal">
-        <label for="{alt}">
-            <div class="modal-content">
-                <img class="modal-photo" loading="lazy" src="{src}" alt="{alt}">
-            </div>
+        <label for="{fid}" class="modal-content">
+            <img class="modal-photo" loading="lazy" src="{src}" alt="{alt}">
         </label>
     </div>
 </figure>
 """
 
 video = """
-<video controls>
-    <source src="{src}" type="video/mp4">
-    </source>
-</video>
+<video controls preload=metadata playsinline src="{src}"></video>
+"""
+
+file_link = """
+<a class=file href="{src}" target="_blank" rel="noopener">
+    <span aria-hidden=true>&#128206;</span>
+    <span>{name}</span>
+</a>
 """

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -1,0 +1,86 @@
+from sigexport import create, models
+
+
+def raw(**kwargs: object) -> models.RawMessage:
+    base = dict(
+        conversation_id="c",
+        id="i",
+        body="",
+        type="incoming",
+        source=None,
+        timestamp=1000,
+        sent_at=1000,
+        server_timestamp=None,
+        has_attachments=False,
+        attachments=[],
+        read_status=None,
+        seen_status=None,
+        call_history=None,
+        reactions=[],
+        sticker=None,
+        quote=None,
+        deleted=False,
+        has_visual_media=False,
+    )
+    base.update(kwargs)
+    return models.RawMessage(**base)  # type: ignore[arg-type]
+
+
+CONTACTS = {
+    "c": models.Contact(
+        id="c",
+        serviceId="s",
+        name="Aya",
+        number="",
+        profile_name="",
+        is_group=False,
+        members=None,
+    )
+}
+
+
+def build(msg: models.RawMessage) -> models.Message:
+    return create.create_message(msg, "Aya", False, CONTACTS)
+
+
+def test_image_only_reply_is_labelled_photo() -> None:
+    """A reply to an image (no quoted text) should still read as a reply."""
+    msg = raw(
+        body="nice",
+        quote={"text": None, "attachments": [{"contentType": "image/jpeg"}]},
+    )
+    assert "> Photo" in build(msg).quote
+
+
+def test_voice_note_reply_is_labelled() -> None:
+    msg = raw(body="lol", quote={"attachments": [{"contentType": "audio/aac"}]})
+    assert "> Voice message" in build(msg).quote
+
+
+def test_reply_with_text_keeps_text() -> None:
+    msg = raw(body="agreed", quote={"text": "original words"})
+    assert "> original words" in build(msg).quote
+
+
+def test_reply_with_no_text_and_no_attachments_has_no_quote() -> None:
+    msg = raw(body="hmm", quote={"text": ""})
+    assert build(msg).quote == ""
+
+
+def test_unexported_visual_attachment_gets_media_placeholder() -> None:
+    """Attachments the export skipped shouldn't vanish into a blank message."""
+    msg = raw(body="here", has_attachments=1, has_visual_media=1, attachments=[])
+    atts = build(msg).attachments
+    assert len(atts) == 1
+    assert atts[0].missing_kind == "media"
+
+
+def test_unexported_file_attachment_gets_generic_placeholder() -> None:
+    msg = raw(body="doc", has_attachments=1, has_visual_media=0, attachments=[])
+    atts = build(msg).attachments
+    assert len(atts) == 1
+    assert atts[0].missing_kind == "attachment"
+
+
+def test_no_placeholder_when_message_had_no_attachments() -> None:
+    assert build(raw(body="plain")).attachments == []

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+from pathlib import Path
 
 from sigexport import html, models
 
@@ -18,6 +19,9 @@ def msg(
         sticker=kwargs.get("sticker"),  # type: ignore[arg-type]
         reactions=kwargs.get("reactions", []),  # type: ignore[arg-type]
         attachments=kwargs.get("attachments", []),  # type: ignore[arg-type]
+        deleted=kwargs.get("deleted", False),  # type: ignore[arg-type]
+        call=kwargs.get("call", False),  # type: ignore[arg-type]
+        missed=kwargs.get("missed", False),  # type: ignore[arg-type]
     )
 
 
@@ -94,3 +98,69 @@ def test_link_at_end_of_message_does_not_swallow_closing_tag() -> None:
     out = html.create_html("Chat", [msg(body="look https://example.com")])
     assert 'href="https://example.com"' in out
     assert "&lt;/p&gt;" not in out
+
+
+def test_deleted_message_shows_placeholder_not_blank() -> None:
+    """A message deleted for everyone should read as deleted, not an empty bubble."""
+    out = html.create_html("Chat", [msg(body="", deleted=True)])
+    assert "deleted" in out
+    assert "This message was deleted" in out
+
+
+def test_deleted_message_hides_original_content() -> None:
+    """Any residual body/attachment must not leak out of a deleted message."""
+    attachment = models.Attachment(name="secret.jpg", path="media/secret.jpg")
+    out = html.create_html(
+        "Chat", [msg(body="oops wrong chat", deleted=True, attachments=[attachment])]
+    )
+    assert "oops wrong chat" not in out
+    assert "secret.jpg" not in out
+    assert "This message was deleted" in out
+
+
+def test_deleted_message_markdown_placeholder() -> None:
+    """The Markdown export should not emit a blank line for a deleted message."""
+    rendered = msg(body="", deleted=True).to_md()
+    assert "(This message was deleted)" in rendered
+
+
+def test_call_renders_as_event_not_bubble() -> None:
+    out = html.create_html("Chat", [msg(body="Incoming voice call (accepted)", call=True)])
+    assert 'class="event' in out
+    assert "Incoming voice call (accepted)" in out
+    # not a chat bubble
+    assert 'class="msg' not in out
+
+
+def test_missed_call_gets_missed_class() -> None:
+    out = html.create_html("Chat", [msg(body="Missed voice call", call=True, missed=True)])
+    assert "event call missed" in out
+
+
+def test_video_call_uses_video_icon() -> None:
+    out = html.create_html(
+        "Chat", [msg(body="Outgoing video call (accepted)", call=True)]
+    )
+    assert "\U0001f4f9" in out  # video camera
+
+
+def test_missing_attachment_shows_placeholder(tmp_path: Path) -> None:
+    """An image whose file isn't in the export reads as excluded, not blank."""
+    attachment = models.Attachment(name="photo.jpg", path="media/photo.jpg")
+    # tmp_path has no media/photo.jpg, so it counts as not exported
+    out = html.create_html(
+        "Chat", [msg(body="pic", attachments=[attachment])], media_dir=tmp_path
+    )
+    assert "Image not exported" in out
+    assert "<img" not in out
+
+
+def test_present_attachment_renders_normally(tmp_path: Path) -> None:
+    attachment = models.Attachment(name="photo.jpg", path="media/photo.jpg")
+    (tmp_path / "media").mkdir()
+    (tmp_path / "media" / "photo.jpg").write_bytes(b"x")
+    out = html.create_html(
+        "Chat", [msg(body="pic", attachments=[attachment])], media_dir=tmp_path
+    )
+    assert "not exported" not in out
+    assert "media/photo.jpg" in out

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -164,3 +164,18 @@ def test_present_attachment_renders_normally(tmp_path: Path) -> None:
     )
     assert "not exported" not in out
     assert "media/photo.jpg" in out
+
+
+def test_image_reply_renders_as_quote() -> None:
+    """A reply whose quote is just a photo label still shows the reply block."""
+    out = html.create_html("Chat", [msg(body="nice", quote="\n\n> Photo\n\n")])
+    assert 'class="quote"' in out
+    assert "Photo" in out
+
+
+def test_sentinel_attachment_renders_placeholder() -> None:
+    """An attachment marked missing (no file at all) shows its placeholder."""
+    att = models.Attachment(name="", path="", missing_kind="media")
+    out = html.create_html("Chat", [msg(body="here", attachments=[att])])
+    assert "Media not exported" in out
+    assert "<img" not in out

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -1,23 +1,96 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from sigexport import html, models
 
 
-def make_message(body: str) -> models.Message:
+def msg(
+    offset_minutes: int = 0,
+    sender: str = "Alice",
+    body: str = "hello",
+    **kwargs: object,
+) -> models.Message:
+    base = datetime(2024, 6, 1, 14, 0, 0)
     return models.Message(
-        date=datetime(2025, 1, 1, 12, 0, 0),
-        sender="Alice",
+        date=base + timedelta(minutes=offset_minutes),
+        sender=sender,
         body=body,
-        quote="",
-        sticker=None,
-        reactions=[],
-        attachments=[],
+        quote=kwargs.get("quote", ""),  # type: ignore[arg-type]
+        sticker=kwargs.get("sticker"),  # type: ignore[arg-type]
+        reactions=kwargs.get("reactions", []),  # type: ignore[arg-type]
+        attachments=kwargs.get("attachments", []),  # type: ignore[arg-type]
     )
 
 
-def test_link_at_end_of_message_does_not_swallow_closing_tag() -> None:
-    """A trailing URL must not absorb the </p> Markdown emitted around it."""
-    out = html.create_html("Alice", [make_message("look https://example.com")])
+def test_theme_switcher_and_assets_present() -> None:
+    out = html.create_html("Chat", [msg()])
+    assert 'data-theme-choice="auto"' in out
+    assert 'data-theme-choice="light"' in out
+    assert 'data-theme-choice="dark"' in out
+    assert "chat.js" in out
+    assert "style.css" in out
 
+
+def test_name_is_escaped_not_injected() -> None:
+    out = html.create_html("<script>evil</script>", [msg()])
+    assert "<script>evil" not in out
+    assert "&lt;script&gt;evil" in out
+
+
+def test_consecutive_messages_are_grouped() -> None:
+    """A quick follow-up from the same sender hides the repeated meta header."""
+    out = html.create_html("Chat", [msg(0), msg(1)])
+    assert out.count('class="sender"') == 1
+    assert "msg cont" in out
+
+
+def test_sender_change_breaks_grouping() -> None:
+    out = html.create_html("Chat", [msg(0, sender="Alice"), msg(1, sender="Bob")])
+    assert out.count('class="sender"') == 2
+
+
+def test_day_divider_between_dates() -> None:
+    out = html.create_html("Chat", [msg(0), msg(60 * 24)])
+    assert out.count('class="day"') == 2
+
+
+def test_pagination_splits_pages_and_adds_pager() -> None:
+    messages = [msg(i) for i in range(5)]
+    out = html.create_html("Chat", messages, msgs_per_page=2)
+    assert out.count('class="page"') == 3
+    assert 'class="pager"' in out
+    assert "/ 3" in out
+
+
+def test_page_jump_field_is_readonly_until_js() -> None:
+    """The jump input ships readonly so the arrows still work with JS off."""
+    messages = [msg(i) for i in range(5)]
+    out = html.create_html("Chat", messages, msgs_per_page=2)
+    assert 'class="pagejump"' in out
+    assert 'max="3"' in out
+    assert "readonly" in out
+
+
+def test_no_pager_on_single_page() -> None:
+    out = html.create_html("Chat", [msg()], msgs_per_page=100)
+    assert 'class="pager"' not in out
+
+
+def test_non_media_attachment_becomes_file_link() -> None:
+    attachment = models.Attachment(name="report.pdf", path="media/report.pdf")
+    out = html.create_html("Chat", [msg(attachments=[attachment])])
+    assert 'class="file"' in out
+    assert "report.pdf" in out
+
+
+def test_image_attachment_gets_lightbox() -> None:
+    attachment = models.Attachment(name="cat.jpg", path="media/cat.jpg")
+    out = html.create_html("Chat", [msg(attachments=[attachment])])
+    assert "modal-state" in out
+    assert "media/cat.jpg" in out
+
+
+def test_link_at_end_of_message_does_not_swallow_closing_tag() -> None:
+    """A trailing URL must not absorb the </p> Markdown emitted around it (#225)."""
+    out = html.create_html("Chat", [msg(body="look https://example.com")])
     assert 'href="https://example.com"' in out
     assert "&lt;/p&gt;" not in out


### PR DESCRIPTION
Reworks the HTML export into a chat-style view and adds colour theming.

## Theming
- Colours defined once via CSS `light-dark()` custom properties. **Auto** mode follows the browser/OS `prefers-color-scheme` with no JS required.
- A switcher in the top bar (**Auto / Light / Dark**) pins a choice, stored per browser in `localStorage` and applied before first paint to avoid a flash of the wrong theme. Degrades gracefully with JS or storage disabled (the switcher hides itself; auto theming still works).

## Layout
- Message bubbles (incoming left, own messages right), consecutive same-sender messages grouped, day dividers, reaction chips, styled quotes, and an image lightbox.
- Compact floating pager replacing the old fixed PREV/NEXT/FIRST/LAST, with a jump-to-page field (readonly until JS enables it, so the arrows still work without JS).
- Keyboard nav: left/right to page, Esc closes the lightbox. Responsive layout plus a print stylesheet.

## Other
- Escapes user-controlled values (sender, quote text, reactions, attachment names, chat title) that the previous templates inserted raw.
- CSS and JS now live in their own files (`style.css`, `chat.js`), both copied into the export root by `prep_html`.
- Adds tests for the HTML generation (`tests/test_html.py`).

Verified rendering in a headless browser in light and dark; `ruff`, `ty`, and the test suite all pass.