### PR TITLE
Fix --overwrite footgun

### DIFF
--- a/sigexport/main.py
+++ b/sigexport/main.py
@@ -1,6 +1,5 @@
 """Main script for sigexport."""
 
-import shutil
 from datetime import datetime
 from pathlib import Path
 
@@ -62,6 +61,12 @@ def main(
         False,
         "--overwrite/--no-overwrite",
         help="Overwrite contents of output directory if it exists",
+    ),
+    yes: bool = Option(
+        False,
+        "--yes",
+        "-y",
+        help="Skip the confirmation prompt when overwriting",
     ),
     verbose: bool = Option(False, "--verbose", "-v"),
     channel_members_only: bool = Option(
@@ -145,7 +150,7 @@ def main(
     if not dest.is_dir():
         dest.mkdir(parents=True, exist_ok=True)
     elif overwrite:
-        shutil.rmtree(dest)
+        utils.safe_delete(dest, yes=yes)
         dest.mkdir(parents=True, exist_ok=True)
     else:
         secho(

--- a/sigexport/utils.py
+++ b/sigexport/utils.py
@@ -1,3 +1,4 @@
+import shutil
 import sys
 from datetime import datetime
 from importlib.metadata import version
@@ -5,7 +6,7 @@ from pathlib import Path
 from typing import Any, TypedDict, TypeGuard
 
 import emoji
-from typer import Exit, secho
+from typer import Exit, colors, confirm, secho
 
 from sigexport import models
 
@@ -108,6 +109,106 @@ def display_name(
     if name is not None:
         return name
     return profile_name
+
+
+# Top-level system directories that should never *themselves* be a target.
+# We only refuse an exact match (not their contents), so e.g. /var/backups is
+# still allowed; that case is handled by the looks-like-an-export check.
+SYSTEM_DIRS = (
+    "/bin",
+    "/boot",
+    "/dev",
+    "/etc",
+    "/lib",
+    "/lib64",
+    "/opt",
+    "/proc",
+    "/root",
+    "/run",
+    "/sbin",
+    "/sys",
+    "/usr",
+    "/var",
+)
+
+
+def is_dangerous_overwrite_target(dest: Path) -> str | None:
+    """Return a reason string if `dest` is too dangerous to delete, else None.
+
+    These paths are never a legitimate export target, so `--overwrite` must
+    refuse them outright rather than recursively deleting them.
+    """
+    resolved = dest.expanduser().resolve()
+    if resolved == Path(resolved.anchor):
+        return "the filesystem root"
+    if resolved == Path.home().resolve():
+        return "your home directory"
+    cwd = Path.cwd().resolve()
+    if resolved == cwd:
+        return "the current working directory"
+    if resolved in cwd.parents:
+        return "a parent of the current working directory"
+    for sysdir in SYSTEM_DIRS:
+        # resolve() so /var matches even where it's a symlink (e.g. macOS)
+        if resolved == Path(sysdir).resolve():
+            return f"a system directory ({sysdir})"
+    return None
+
+
+def looks_like_export_dir(dest: Path) -> bool:
+    """Whether `dest` looks like a previous signal-export output.
+
+    Used to avoid `--overwrite` deleting an arbitrary directory the user
+    pointed at by mistake. An empty directory is fine; otherwise we look for
+    our own artifacts (the root stylesheet, or a chat folder with its files).
+    """
+    try:
+        entries = list(dest.iterdir())
+    except OSError:
+        return False
+    if not entries:
+        return True
+    if (dest / "style.css").is_file():
+        return True
+    markers = ("chat.md", "index.html", "data.json")
+    for child in entries:
+        if child.is_dir() and any((child / m).is_file() for m in markers):
+            return True
+    return False
+
+
+def safe_delete(dest: Path, yes: bool = False) -> None:
+    """Recursively delete `dest`, refusing dangerous or non-export targets.
+
+    Guards `--overwrite` before removing an existing output directory: refuses
+    obviously dangerous targets (root, home, the cwd, a system dir) and
+    directories that don't look like a previous export, and asks for
+    confirmation when running interactively (skip with `yes`).
+    """
+    reason = is_dangerous_overwrite_target(dest)
+    if reason:
+        secho(
+            f"Refusing to delete {dest.resolve()}: that's {reason}.",
+            fg=colors.RED,
+        )
+        raise Exit(1)
+
+    if not looks_like_export_dir(dest):
+        secho(
+            f"'{dest}' doesn't look like a signal-export output "
+            "(no style.css or chat folders), so it won't be deleted. "
+            "Remove it yourself or choose another path.",
+            fg=colors.RED,
+        )
+        raise Exit(1)
+
+    if not yes and sys.stdin.isatty():
+        count = sum(1 for _ in dest.iterdir())
+        if not confirm(f"Delete {count} item(s) in {dest.resolve()} and re-export?"):
+            secho("Aborted.", fg=colors.YELLOW)
+            raise Exit(1)
+
+    shutil.rmtree(dest)
 
 
 def fix_names(contacts: models.Contacts) -> models.Contacts:

--- a/tests/test_overwrite.py
+++ b/tests/test_overwrite.py
@@ -1,0 +1,93 @@
+from pathlib import Path
+
+import pytest
+from typer import Exit
+
+from sigexport import utils
+
+
+def test_root_is_refused() -> None:
+    assert utils.is_dangerous_overwrite_target(Path("/")) == "the filesystem root"
+
+
+def test_home_is_refused() -> None:
+    assert utils.is_dangerous_overwrite_target(Path.home()) == "your home directory"
+
+
+def test_cwd_is_refused() -> None:
+    assert (
+        utils.is_dangerous_overwrite_target(Path.cwd())
+        == "the current working directory"
+    )
+
+
+def test_parent_of_cwd_is_refused() -> None:
+    reason = utils.is_dangerous_overwrite_target(Path.cwd().parent)
+    assert reason == "a parent of the current working directory"
+
+
+def test_var_itself_is_refused() -> None:
+    assert utils.is_dangerous_overwrite_target(Path("/var")) == "a system directory (/var)"
+
+
+def test_var_subdir_is_allowed() -> None:
+    """We only block /var itself, not sensible sub-paths like /var/backups."""
+    assert utils.is_dangerous_overwrite_target(Path("/var/backups/signal")) is None
+
+
+def test_normal_target_is_allowed(tmp_path: Path) -> None:
+    assert utils.is_dangerous_overwrite_target(tmp_path / "export") is None
+
+
+def test_empty_dir_looks_like_export(tmp_path: Path) -> None:
+    assert utils.looks_like_export_dir(tmp_path) is True
+
+
+def test_dir_with_stylesheet_looks_like_export(tmp_path: Path) -> None:
+    (tmp_path / "style.css").write_text("body {}")
+    assert utils.looks_like_export_dir(tmp_path) is True
+
+
+def test_dir_with_chat_folder_looks_like_export(tmp_path: Path) -> None:
+    chat = tmp_path / "Alice"
+    chat.mkdir()
+    (chat / "chat.md").write_text("hi")
+    assert utils.looks_like_export_dir(tmp_path) is True
+
+
+def test_json_only_export_is_recognised(tmp_path: Path) -> None:
+    """A --no-html export has no style.css, but data.json still marks it."""
+    chat = tmp_path / "Alice"
+    chat.mkdir()
+    (chat / "data.json").write_text("{}")
+    assert not (tmp_path / "style.css").exists()
+    assert utils.looks_like_export_dir(tmp_path) is True
+
+
+def test_unrelated_dir_is_not_an_export(tmp_path: Path) -> None:
+    (tmp_path / "taxes.pdf").write_text("important")
+    (tmp_path / "photos").mkdir()
+    assert utils.looks_like_export_dir(tmp_path) is False
+
+
+def test_safe_delete_removes_an_export_dir(tmp_path: Path) -> None:
+    export = tmp_path / "out"
+    export.mkdir()
+    (export / "style.css").write_text("body {}")
+    utils.safe_delete(export, yes=True)
+    assert not export.exists()
+
+
+def test_safe_delete_refuses_unrelated_dir(tmp_path: Path) -> None:
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "taxes.pdf").write_text("important")
+    with pytest.raises(Exit):
+        utils.safe_delete(docs, yes=True)
+    assert docs.exists()  # nothing deleted
+
+
+def test_safe_delete_refuses_dangerous_target() -> None:
+    with pytest.raises(Exit):
+        utils.safe_delete(Path.home(), yes=True)
+    assert Path.home().exists()


### PR DESCRIPTION
`--overwrite` ran `shutil.rmtree(dest)` unconditionally, so a typo like `--overwrite ~/` or `--overwrite /var` would recursively delete the target with no checks. This adds guardrails before the delete.

## Behaviour

- **Hard-refuse dangerous targets:** the filesystem root, your home directory, the current working directory (or a parent of it), and top-level system directories (`/etc`, `/usr`, `/var`, ...). These are *exact* matches, so sensible sub-paths like `/var/backups/signal` are still allowed.
- **Refuse unrelated directories:** if the target isn't empty and doesn't look like a previous export (no `style.css` at the root and no chat folder containing `chat.md`/`index.html`/`data.json`), it won't be deleted. This covers `--no-html` JSON-only exports too, via the per-chat `data.json`/`chat.md` markers.
- **Confirm interactively:** when stdin is a TTY, prompt before deleting, showing the resolved path and item count. Add `--yes`/`-y` to skip the prompt.

## Compatibility

Non-interactive runs (cron, CI) that pass the safety checks still proceed **without** a prompt, so existing scripted `--overwrite` of a real export directory keeps working. Only the dangerous/unrelated targets are newly refused.

Adds tests for the guards (dangerous paths, export detection incl. JSON-only exports).