### PR TITLE
Export "Note to Self" and stop nameless contacts colliding

### DIFF
--- a/sigexport/data.py
+++ b/sigexport/data.py
@@ -189,7 +189,7 @@ def fetch_data(
     owner_row = c.execute("select ourServiceId from sessions").fetchone()
     owner_id = owner_row[0] if owner_row is not None else None
     contact_by_service_id: models.Contacts = {c.serviceId: c for c in contacts.values()}
-    owner_contact = contact_by_service_id[owner_id] if owner_id else None
+    owner_contact = contact_by_service_id.get(owner_id) if owner_id else None
 
     return convos, contacts, owner_contact
 

--- a/sigexport/main.py
+++ b/sigexport/main.py
@@ -146,6 +146,11 @@ def main(
         )
         raise Exit()
 
+    # The conversation with your own account is Signal's "Note to Self"; it
+    # usually has no name and would otherwise land in the shared "None" folder.
+    if owner is not None:
+        owner.name = "Note to Self"
+
     contacts = utils.fix_names(contacts)
 
     if stickers:

--- a/sigexport/utils.py
+++ b/sigexport/utils.py
@@ -85,25 +85,33 @@ def source_location() -> Path:
 
 
 def fix_names(contacts: models.Contacts) -> models.Contacts:
-    """Convert contact names to filesystem-friendly."""
-    fixed_contact_names = set()
-    for key, item in contacts.items():
-        contact_name = item.number if item.name is None else item.name
-        if contacts[key].name is not None:
-            contacts[key].name = "".join(
-                x for x in emoji.demojize(contact_name) if x.isalnum()
-            )
-            if contacts[key].name == "":
-                contacts[key].name = "unnamed"
-            fixed_contact_name = contacts[key].name
-            if fixed_contact_name in fixed_contact_names:
-                name_differentiating_number = 2
-                while (
-                    fixed_contact_name + str(name_differentiating_number)
-                ) in fixed_contact_names:
-                    name_differentiating_number += 1
-                fixed_contact_name += str(name_differentiating_number)
-                contacts[key].name = fixed_contact_name
-            fixed_contact_names.add(fixed_contact_name)
+    """Convert contact names to filesystem-friendly, de-duplicating collisions.
+
+    Every contact ends up with a non-empty, unique name so each gets its own
+    output folder. Nameless contacts previously kept ``None`` and all collided
+    in a single ``None/`` folder (their messages interleaved); now they are
+    de-duplicated like any other clash.
+
+    Iteration is in a stable order (serviceId, then id) so the numeric suffixes
+    are deterministic across exports and a contact keeps the same folder from
+    run to run (important for ``--old`` merges).
+    """
+    used: set[str] = set()
+    for key in sorted(contacts, key=lambda k: (contacts[k].serviceId or "", k)):
+        item = contacts[key]
+        if item.name is None:
+            base = "None"
+        else:
+            base = "".join(x for x in emoji.demojize(item.name) if x.isalnum())
+            if base == "":
+                base = "unnamed"
+
+        name = base
+        suffix = 2
+        while name in used:
+            name = f"{base}{suffix}"
+            suffix += 1
+        used.add(name)
+        item.name = name
 
     return contacts

--- a/tests/test_names.py
+++ b/tests/test_names.py
@@ -1,0 +1,68 @@
+from sigexport import models, utils
+
+
+def contact(
+    cid: str,
+    name: str | None,
+    service_id: str = "",
+    is_group: bool = False,
+) -> models.Contact:
+    return models.Contact(
+        id=cid,
+        serviceId=service_id,
+        name=name,
+        number="",
+        profile_name="",
+        is_group=is_group,
+        members=None,
+    )
+
+
+def names(contacts: models.Contacts) -> dict[str, str | None]:
+    utils.fix_names(contacts)
+    return {cid: c.name for cid, c in contacts.items()}
+
+
+def test_distinct_names_are_kept() -> None:
+    out = names({"1": contact("1", "Alice", "a"), "2": contact("2", "Bob", "b")})
+    assert out == {"1": "Alice", "2": "Bob"}
+
+
+def test_colliding_names_are_numbered() -> None:
+    out = names({"1": contact("1", "Alex", "a"), "2": contact("2", "Alex", "b")})
+    assert out == {"1": "Alex", "2": "Alex2"}
+
+
+def test_nameless_contacts_do_not_all_become_none() -> None:
+    """The core bug: multiple no-name contacts used to share one None/ folder."""
+    out = names(
+        {
+            "1": contact("1", None, "a"),
+            "2": contact("2", None, "b"),
+            "3": contact("3", None, "c"),
+        }
+    )
+    assert sorted(out.values()) == ["None", "None2", "None3"]
+
+
+def test_suffix_assignment_is_deterministic_by_service_id() -> None:
+    """Insertion order must not decide who keeps the bare name."""
+    forward = names({"1": contact("1", "Sam", "aaa"), "2": contact("2", "Sam", "bbb")})
+    reverse = names({"2": contact("2", "Sam", "bbb"), "1": contact("1", "Sam", "aaa")})
+    assert forward == reverse == {"1": "Sam", "2": "Sam2"}
+
+
+def test_note_to_self_label_is_filesystem_safe() -> None:
+    out = names({"1": contact("1", "Note to Self", "self")})
+    assert out == {"1": "NotetoSelf"}
+
+
+def test_spaces_and_punctuation_are_stripped() -> None:
+    out = names({"1": contact("1", "John Smith", "a")})
+    assert out == {"1": "JohnSmith"}
+
+
+def test_emoji_only_name_falls_back_to_unnamed() -> None:
+    # a name that demojizes to nothing alphanumeric... use a bare symbol
+    out = names({"1": contact("1", "!!!", "a")})
+    assert out == {"1": "unnamed"}


### PR DESCRIPTION
Contacts with no name all fell through to the literal name `None` and were written into a single shared `None/` folder. Because `chat.md`/`data.json` are opened in append mode, their messages were **interleaved** into one file. The conversation with your own account (Signal's "Note to Self") has no name, so it hit exactly this: effectively lost among other nameless chats.

## Changes

- **Label "Note to Self".** The owner conversation (the one whose `serviceId` matches your own account) is named "Note to Self" so it gets its own folder instead of falling into `None/`.
- **De-duplicate nameless contacts.** `fix_names` now gives every contact a unique name; nameless ones become `None`, `None2`, … like any other collision, instead of sharing one folder.
- **Deterministic ordering.** Contacts are processed in a stable order (`serviceId`, then id), so the numeric suffixes are the same across exports and a contact keeps the same folder run to run (matters for `--old` merges).
- **Harden owner lookup.** Use `.get()` so an account with no self-conversation doesn't `KeyError`.

## Notes

- Folder names strip non-alphanumerics as before, so "Note to Self" becomes `NotetoSelf/` (consistent with `John Smith` → `JohnSmith`).
- Because suffix assignment is now order-independent, upgrading users may see a **one-off** change to which of a set of same-named contacts keeps the bare name (e.g. which `Alex` vs `Alex2`); it's stable afterwards. Non-colliding names are unaffected.

Adds tests for the naming rules (collisions, nameless de-dup, deterministic ordering, filesystem-safe labels).