### PR TITLE
Add --nicknames to use Signal nicknames for names and folders

### DIFF
--- a/sigexport/data.py
+++ b/sigexport/data.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from sqlcipher3 import dbapi2
 from typer import Exit, colors, secho
 
-from sigexport import crypto, models
+from sigexport import crypto, models, utils
 from sigexport.logging import log
 
 
@@ -68,6 +68,7 @@ def fetch_data(
     include_disappearing: bool,
     start_date: datetime | None = None,
     end_date: datetime | None = None,
+    nicknames: bool = False,
 ) -> tuple[models.Convos, models.Contacts, models.Contact | None]:
     """Load SQLite data into dicts.
     :returns: a tuple of:
@@ -84,8 +85,9 @@ def fetch_data(
 
     call_directions = _load_call_directions(c)
 
-    query = "SELECT type, id, serviceId, e164, name, profileName, members FROM conversations"
+    query = "SELECT type, id, serviceId, e164, name, profileName, members, json FROM conversations"
     c.execute(query)
+    nickname_count = 0
     for result in c:
         log(f"\tLoading SQL results for: {result[4]}, aka {result[5]}")
         members = []
@@ -93,20 +95,41 @@ def fetch_data(
             members = result[6].split(" ")
         is_group = result[0] == "group"
         cid = result[1]
+
+        # Nicknames live in the conversation JSON, not a dedicated column.
+        nickname = None
+        if nicknames and result[7]:
+            try:
+                conv_json = json.loads(result[7])
+            except (TypeError, ValueError):
+                conv_json = {}
+            nickname = utils.format_nickname(
+                conv_json.get("nicknameGivenName"),
+                conv_json.get("nicknameFamilyName"),
+            )
+            if nickname:
+                nickname_count += 1
+
         contact = models.Contact(
             id=cid,
             serviceId=result[2],
-            name=result[4],
+            name=utils.display_name(result[4], result[5], nickname),
             number=result[3],
             profile_name=result[5],
             members=members,
             is_group=is_group,
         )
-        if contact.name is None:
-            contact.name = contact.profile_name
         contacts[cid] = contact
-        if not chats or (result[4] in chats_list or result[5] in chats_list):
+
+        match_names = [result[4], result[5], nickname]
+        if not chats or any(n and n in chats_list for n in match_names):
             convos[cid] = []
+
+    if nicknames and nickname_count == 0:
+        secho(
+            "Note: --nicknames was set but no nicknames were found in this Signal DB.",
+            fg=colors.YELLOW,
+        )
 
     # Check which columns exist (older DB schemas may be missing some)
     c.execute("PRAGMA table_info(messages)")

--- a/sigexport/main.py
+++ b/sigexport/main.py
@@ -72,6 +72,12 @@ def main(
     attachments: bool = Option(
         True, "--attachments/--no-attachments", help="Whether to copy attachments"
     ),
+    nicknames: bool = Option(
+        False,
+        "--nicknames/--no-nicknames",
+        help="Use Signal nicknames (where set) for names and folders, "
+        "instead of profile names",
+    ),
     _: bool = Option(False, "--version", callback=utils.version_callback),
 ) -> None:
     """
@@ -121,6 +127,7 @@ def main(
         include_disappearing=include_disappearing,
         start_date=parsed_start_date,
         end_date=parsed_end_date,
+        nicknames=nicknames,
     )
 
     if list_chats:

--- a/sigexport/utils.py
+++ b/sigexport/utils.py
@@ -84,6 +84,32 @@ def source_location() -> Path:
     return source_path
 
 
+def format_nickname(given: str | None, family: str | None) -> str | None:
+    """Combine Signal's nickname given/family parts into one name, or None.
+
+    Signal stores nicknames split into given and family parts in the
+    conversation JSON (`nicknameGivenName` / `nicknameFamilyName`); either may
+    be absent.
+    """
+    parts = [p.strip() for p in (given, family) if p and p.strip()]
+    return " ".join(parts) if parts else None
+
+
+def display_name(
+    name: str | None, profile_name: str | None, nickname: str | None
+) -> str | None:
+    """Pick the name to show for a contact.
+
+    A nickname (when present and requested) wins, then the system/contact
+    name, then the profile name; mirrors Signal's own precedence.
+    """
+    if nickname:
+        return nickname
+    if name is not None:
+        return name
+    return profile_name
+
+
 def fix_names(contacts: models.Contacts) -> models.Contacts:
     """Convert contact names to filesystem-friendly."""
     fixed_contact_names = set()

--- a/tests/test_nicknames.py
+++ b/tests/test_nicknames.py
@@ -1,0 +1,95 @@
+import json
+import sqlite3
+from pathlib import Path
+
+from sigexport import data, utils
+
+
+def make_cursor(conv_json: dict) -> sqlite3.Cursor:
+    """A minimal in-memory stand-in for the Signal DB with one contact."""
+    con = sqlite3.connect(":memory:")
+    cur = con.cursor()
+    cur.execute(
+        "CREATE TABLE conversations "
+        "(type, id, serviceId, e164, name, profileName, members, json)"
+    )
+    cur.execute(
+        "CREATE TABLE messages (conversationId, type, json, id, body, "
+        "sourceServiceId, timestamp, sent_at, serverTimestamp, hasAttachments, "
+        "readStatus, seenStatus, expireTimer)"
+    )
+    cur.execute("CREATE TABLE sessions (ourServiceId)")
+    cur.execute(
+        "CREATE TABLE callsHistory "
+        "(callId, direction, status, type, timestamp, endedTimestamp)"
+    )
+    cur.execute(
+        "INSERT INTO conversations VALUES (?,?,?,?,?,?,?,?)",
+        ("private", "c1", "sid1", None, None, "KC", None, json.dumps(conv_json)),
+    )
+    cur.execute(
+        "INSERT INTO messages VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)",
+        ("c1", "incoming", json.dumps({}), "m1", "hi", None, 1, 1000, None, 0, None, None, None),
+    )
+    cur.execute("INSERT INTO sessions VALUES (?)", ("sid1",))
+    con.commit()
+    return cur
+
+
+def contact_name(nicknames: bool, conv_json: dict) -> str | None:
+    cur = make_cursor(conv_json)
+    _, contacts, _ = data.fetch_data(
+        Path("/unused"),
+        cur,
+        chats="",
+        include_empty=False,
+        include_disappearing=False,
+        nicknames=nicknames,
+    )
+    return contacts["c1"].name
+
+
+def test_fetch_data_uses_nickname_when_enabled() -> None:
+    assert contact_name(True, {"nicknameGivenName": "Nocturnal"}) == "Nocturnal"
+
+
+def test_fetch_data_ignores_nickname_when_disabled() -> None:
+    # falls back to profileName ("KC") since name is NULL
+    assert contact_name(False, {"nicknameGivenName": "Nocturnal"}) == "KC"
+
+
+def test_fetch_data_without_nickname_set_falls_back() -> None:
+    assert contact_name(True, {}) == "KC"
+
+
+def test_format_nickname_given_only() -> None:
+    assert utils.format_nickname("Nocturnal", None) == "Nocturnal"
+
+
+def test_format_nickname_given_and_family() -> None:
+    assert utils.format_nickname("Ada", "Lovelace") == "Ada Lovelace"
+
+
+def test_format_nickname_family_only() -> None:
+    assert utils.format_nickname(None, "Lovelace") == "Lovelace"
+
+
+def test_format_nickname_empty_is_none() -> None:
+    assert utils.format_nickname(None, None) is None
+    assert utils.format_nickname("", "  ") is None
+
+
+def test_display_name_prefers_nickname() -> None:
+    assert utils.display_name("KC", "KC", "Nocturnal") == "Nocturnal"
+
+
+def test_display_name_without_nickname_uses_name() -> None:
+    assert utils.display_name("Mykayla", "profile", None) == "Mykayla"
+
+
+def test_display_name_falls_back_to_profile_when_no_name() -> None:
+    assert utils.display_name(None, "pandora", None) == "pandora"
+
+
+def test_display_name_ignores_empty_nickname() -> None:
+    assert utils.display_name("KC", "KC", None) == "KC"


### PR DESCRIPTION
By default contacts are named by their profile/system name. Signal also lets you set a private **nickname** per contact, which is often what you actually recognise them by. This adds an opt-in `--nicknames` flag (default **off**, so existing behaviour is unchanged) to prefer it for the display name and output folder.

## Details

- Nicknames aren't a dedicated column; they live in the conversation `json` blob as `nicknameGivenName` / `nicknameFamilyName`. This parses them from there.
- Precedence mirrors Signal: **nickname → system/contact name → profile name**. So a contact stored as `KC` with the nickname `Nocturnal` exports to `Nocturnal/` with the flag on, `KC/` without.
- With the flag on, `--chats <nickname>` also matches.
- If `--nicknames` is set but the DB has no nicknames (older Signal), it prints a note rather than silently doing nothing.

## Tests

- Unit tests for the name-resolution/precedence helpers.
- An in-memory-SQLite integration test that runs `fetch_data` and checks the nickname is (or isn't) applied, exercising the actual `json`-column parsing.
- Smoke tested on our real Signal DB