### PR TITLE
Don't leak the folder de-duplication suffix into conversations

### DIFF
--- a/sigexport/create.py
+++ b/sigexport/create.py
@@ -125,9 +125,10 @@ def create_message(
                 for c in contacts.values():
                     serviceId = c.serviceId
                     if serviceId is not None and serviceId == msg.source:
-                        sender = c.name or "No-Sender"
+                        sender = c.display or c.name or "No-Sender"
             else:
-                sender = contacts[msg.conversation_id].name or "No-Sender"
+                contact = contacts[msg.conversation_id]
+                sender = contact.display or contact.name or "No-Sender"
         except KeyError:
             log(f"\t\tNo sender:\t\t{date}")
 
@@ -149,8 +150,9 @@ def create_message(
     if msg.reactions:
         for r in msg.reactions:
             try:
+                reactor = contacts[r["fromId"]]
                 reactions.append(
-                    models.Reaction(contacts[r["fromId"]].name, r["emoji"])
+                    models.Reaction(reactor.display or reactor.name, r["emoji"])
                 )
             except KeyError:
                 log(

--- a/sigexport/main.py
+++ b/sigexport/main.py
@@ -203,6 +203,9 @@ def main(
         if not name:
             name = "None"
 
+        # `name` is the (unique) folder; `title` is the human name for display
+        title = contacts[key].display or name
+
         (dest / name).mkdir(parents=True, exist_ok=True)
         md_path = dest / name / "chat.md"
         js_path = dest / name / "data.json"
@@ -223,7 +226,7 @@ def main(
                     print(msg.dict_str(), file=js_f)
             if ht_f:
                 ht = html.create_html(
-                    name=name,
+                    name=title,
                     messages=messages,
                     msgs_per_page=paginate,
                     media_dir=dest / name,

--- a/sigexport/models.py
+++ b/sigexport/models.py
@@ -99,6 +99,10 @@ class Contact:
     profile_name: str
     is_group: bool
     members: list[str] | None
+    # Human-readable name for display in the conversation (sender labels,
+    # reactions, HTML title). Unlike `name`, it has no folder-uniqueness
+    # suffix, so two "Alice"s live in Alice/ and Alice2/ but both read "Alice".
+    display: str | None = None
 
 
 Contacts = dict[str, Contact]

--- a/sigexport/utils.py
+++ b/sigexport/utils.py
@@ -222,6 +222,10 @@ def fix_names(contacts: models.Contacts) -> models.Contacts:
     Iteration is in a stable order (serviceId, then id) so the numeric suffixes
     are deterministic across exports and a contact keeps the same folder from
     run to run (important for ``--old`` merges).
+
+    The de-duplication suffix is only applied to ``name`` (the folder). The
+    conversation-facing ``display`` keeps the un-suffixed base, so two "Alice"s
+    live in Alice/ and Alice2/ but both still read "Alice" inside the export.
     """
     used: set[str] = set()
     for key in sorted(contacts, key=lambda k: (contacts[k].serviceId or "", k)):
@@ -239,6 +243,7 @@ def fix_names(contacts: models.Contacts) -> models.Contacts:
             name = f"{base}{suffix}"
             suffix += 1
         used.add(name)
+        item.display = base
         item.name = name
 
     return contacts

--- a/tests/test_names.py
+++ b/tests/test_names.py
@@ -1,4 +1,27 @@
-from sigexport import models, utils
+from sigexport import create, models, utils
+
+
+def raw(**kwargs: object) -> models.RawMessage:
+    base = dict(
+        conversation_id="c",
+        id="i",
+        body="hi",
+        type="incoming",
+        source=None,
+        timestamp=1,
+        sent_at=1,
+        server_timestamp=None,
+        has_attachments=False,
+        attachments=[],
+        read_status=None,
+        seen_status=None,
+        call_history=None,
+        reactions=[],
+        sticker=None,
+        quote=None,
+    )
+    base.update(kwargs)
+    return models.RawMessage(**base)  # type: ignore[arg-type]
 
 
 def contact(
@@ -66,3 +89,33 @@ def test_emoji_only_name_falls_back_to_unnamed() -> None:
     # a name that demojizes to nothing alphanumeric... use a bare symbol
     out = names({"1": contact("1", "!!!", "a")})
     assert out == {"1": "unnamed"}
+
+
+def test_display_drops_the_folder_dedup_suffix() -> None:
+    """Folders disambiguate (Alice / Alice2) but both still read "Alice"."""
+    contacts = {"1": contact("1", "Alice", "a"), "2": contact("2", "Alice", "b")}
+    utils.fix_names(contacts)
+    assert (contacts["1"].name, contacts["2"].name) == ("Alice", "Alice2")
+    assert (contacts["1"].display, contacts["2"].display) == ("Alice", "Alice")
+
+
+def test_group_sender_uses_display_not_suffixed_folder() -> None:
+    """A message from the de-duplicated "Alice2" should still read "Alice"."""
+    contacts = {
+        "a": contact("a", "Alice", "sid-a"),
+        "b": contact("b", "Alice", "sid-b"),
+    }
+    utils.fix_names(contacts)  # a -> Alice, b -> Alice2 (by serviceId order)
+    msg = create.create_message(raw(source="sid-b"), "grp", True, contacts)
+    assert msg.sender == "Alice"
+
+
+def test_one_to_one_sender_uses_display() -> None:
+    contacts = {
+        "a": contact("a", "Alice", "sid-a"),
+        "b": contact("b", "Alice", "sid-b"),
+    }
+    utils.fix_names(contacts)
+    # a 1:1 message in conversation "b" (the de-duplicated Alice2)
+    msg = create.create_message(raw(conversation_id="b"), "Alice2", False, contacts)
+    assert msg.sender == "Alice"


### PR DESCRIPTION
When two contacts share a name, `fix_names` disambiguates the output *folder* (`Alice/`, `Alice2/`). But it wrote that suffixed slug back onto `contact.name` — which is also what sender labels, reaction authors, and the HTML title are built from. So the second Alice's messages read **"Alice2"** *inside* the exported conversation, not just on disk.

The folder should be unique; the displayed name should not carry the disambiguator.

## Fix

- Add `Contact.display`: the un-suffixed, conversation-facing name.
- `fix_names` sets `display` to the base name and `name` to the (possibly suffixed) folder slug.
- Sender/reaction resolution in `create_message`, and the HTML `<title>`, now use `display`; all folder/path code keeps using `name`.

So two "Alice"s live in `Alice/` and `Alice2/`, but both still read "Alice" in the messages, reactions, and titles.

Adds tests that `display` drops the suffix and that a de-duplicated contact's sender resolves to the plain name (both group and 1:1).