### PR TITLE
fix: stop the URL regex from swallowing trailing HTML tags

### DIFF
--- a/sigexport/html.py
+++ b/sigexport/html.py
@@ -73,7 +73,10 @@ def create_html(
             log(f"Maximum recursion on message {body}, not converted")
 
         # links
-        p = re.compile(r"(https{0,1}://\S*)")
+        # Stop at "<" as well as whitespace: the body has already been
+        # converted to HTML, so a URL at the end of a line or message is
+        # directly followed by a tag such as "</p>" or "<br />".
+        p = re.compile(r"(https{0,1}://[^\s<]*)")
         a_template = r"<a href='\1' target='_blank'>\1</a> "
         body = re.sub(p, a_template, body)
 

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -1,0 +1,33 @@
+from datetime import datetime
+
+from bs4 import BeautifulSoup
+
+from sigexport import html, models
+
+
+def make_message(body: str) -> models.Message:
+    return models.Message(
+        date=datetime(2025, 1, 1, 12, 0, 0),
+        sender="Alice",
+        body=body,
+        quote="",
+        sticker=None,
+        reactions=[],
+        attachments=[],
+    )
+
+
+def hrefs(body: str) -> list[str]:
+    out = html.create_html(name="Alice", messages=[make_message(body)])
+    soup = BeautifulSoup(out, "html.parser")
+    return [str(a["href"]) for a in soup.select("span.body a")]
+
+
+def test_link_at_end_of_message_does_not_swallow_closing_tag() -> None:
+    """The body is already HTML, so a trailing URL is followed by "</p>"."""
+    assert hrefs("see https://ex.com") == ["https://ex.com"]
+
+
+def test_link_before_newline_does_not_swallow_break_tag() -> None:
+    """A newline after a link becomes "<br />", which must stay outside it."""
+    assert hrefs("see https://ex.com  \nnext") == ["https://ex.com"]


### PR DESCRIPTION
Closes #164

`create_html` linkifies URLs *after* the body has been converted to HTML, but the pattern matched every non-whitespace character, so a URL at the end of a message or line absorbed the markup that followed it — producing `href='https://ex.com</p>'` and a stray `</p>` inside the anchor text. The pattern now stops at `<` as well as whitespace.
