### PR TITLE
fix: don't create the output folder when no chats are exported

### DIFF
--- a/sigexport/main.py
+++ b/sigexport/main.py
@@ -141,6 +141,10 @@ def main(
         )
         raise Exit()
 
+    if not convos:
+        secho("No chats to export, didn't do anything!", fg=colors.RED)
+        raise Exit()
+
     dest = Path(dest).expanduser()
     if not dest.is_dir():
         dest.mkdir(parents=True, exist_ok=True)

--- a/tests/test_dest_creation.py
+++ b/tests/test_dest_creation.py
@@ -1,0 +1,63 @@
+import json
+from pathlib import Path
+
+import pytest
+import typer
+from typer.testing import CliRunner
+
+from sigexport import data, main, models
+
+
+def make_source(tmp_path: Path) -> Path:
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "config.json").write_text(json.dumps({}))
+    return source
+
+
+def contacts() -> models.Contacts:
+    return {
+        "c1": models.Contact(
+            id="c1",
+            serviceId="sid1",
+            name="Alice",
+            number="",
+            profile_name="",
+            is_group=False,
+            members=None,
+        )
+    }
+
+
+def run_main(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    convos: models.Convos,
+) -> Path:
+    """Run main() with the Signal DB layer stubbed out, returning the dest path."""
+    monkeypatch.setattr(data, "get_signal_database", lambda *a, **k: None)
+    monkeypatch.setattr(data, "fetch_data", lambda *a, **k: (convos, contacts(), None))
+
+    dest = tmp_path / "output"
+    app = typer.Typer()
+    app.command()(main.main)
+    CliRunner().invoke(
+        app,
+        [
+            str(dest),
+            "--source",
+            str(make_source(tmp_path)),
+            "--no-stickers",
+            "--no-attachments",
+        ],
+    )
+    return dest
+
+
+def test_dest_not_created_when_no_chats_exported(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """No chats to export must leave the filesystem untouched, so the command
+    can be rerun without manually deleting a half-made output folder."""
+    dest = run_main(monkeypatch, tmp_path, {})
+    assert not dest.exists()


### PR DESCRIPTION
Closes #207

When the chosen filters matched no conversations, `main()` still created the destination folder (and `style.css`) before discovering there was nothing to write, so the next run aborted with "Output folder already exists, didn't do anything!" until the folder was deleted by hand. It now exits early with a message before touching the filesystem.
