### PR TITLE
Stop link regex from swallowing HTML tags

### DIFF
--- a/sigexport/html.py
+++ b/sigexport/html.py
@@ -73,7 +73,9 @@ def create_html(
             log(f"Maximum recursion on message {body}, not converted")
 
         # links
-        p = re.compile(r"(https{0,1}://\S*)")
+        # body is already HTML at this point, so stop at '<' to avoid swallowing
+        # the tags Markdown emitted (e.g. a trailing </p>) into the href
+        p = re.compile(r"(https{0,1}://[^\s<]*)")
         a_template = r"<a href='\1' target='_blank'>\1</a> "
         body = re.sub(p, a_template, body)
 

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -1,0 +1,23 @@
+from datetime import datetime
+
+from sigexport import html, models
+
+
+def make_message(body: str) -> models.Message:
+    return models.Message(
+        date=datetime(2025, 1, 1, 12, 0, 0),
+        sender="Alice",
+        body=body,
+        quote="",
+        sticker=None,
+        reactions=[],
+        attachments=[],
+    )
+
+
+def test_link_at_end_of_message_does_not_swallow_closing_tag() -> None:
+    """A trailing URL must not absorb the </p> Markdown emitted around it."""
+    out = html.create_html("Alice", [make_message("look https://example.com")])
+
+    assert 'href="https://example.com"' in out
+    assert "&lt;/p&gt;" not in out


### PR DESCRIPTION
Closes #164

`create_html` linkifies URLs after Markdown has already converted the body to HTML, but the pattern matched `\S*`, so a message ending in a link swallowed the closing `</p>` into the `href` and re-emitted it as visible text. Restricting the match to characters before the next `<` fixes it; regression test added in `tests/test_html.py`.
