### PR TITLE
Add --update mode: incremental, data-safe archive merging (#222)

### DIFF
--- a/sigexport/create.py
+++ b/sigexport/create.py
@@ -195,6 +195,7 @@ def create_message(
         deleted=msg.deleted,
         call=is_call,
         missed=missed_call,
+        id=msg.id,
     )
 
 

--- a/sigexport/create.py
+++ b/sigexport/create.py
@@ -196,6 +196,7 @@ def create_message(
         call=is_call,
         missed=missed_call,
         id=msg.id,
+        disappearing=msg.disappearing,
     )
 
 

--- a/sigexport/data.py
+++ b/sigexport/data.py
@@ -204,6 +204,7 @@ def fetch_data(
                 quote=jsonLoaded.get("quote"),
                 deleted=bool(jsonLoaded.get("deletedForEveryone")),
                 has_visual_media=bool(jsonLoaded.get("hasVisualMediaAttachments")),
+                disappearing=bool(expireTimer),
             )
 
             convos[cid].append(con)

--- a/sigexport/files.py
+++ b/sigexport/files.py
@@ -204,6 +204,18 @@ def copy_attachments(
                         continue
                     src_path = src_root / att_path
                     dst_path = dst_root / att["fileName"]
+                    # Skip attachments already present (e.g. an --update re-run):
+                    # the filename is deterministic, so an existing file of the
+                    # expected size is the same attachment. A size mismatch (a
+                    # partial write from an interrupted run) falls through and is
+                    # rewritten.
+                    if dst_path.exists():
+                        try:
+                            expected = int(att.get("size") or 0)
+                        except (TypeError, ValueError):
+                            expected = 0
+                        if not expected or dst_path.stat().st_size == expected:
+                            continue
                     if int(att.get("version", 0)) >= 2:
                         try:
                             decrypt_attachment(att, src_path, dst_path)

--- a/sigexport/main.py
+++ b/sigexport/main.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typer import Argument, Context, Exit, Option, colors, run, secho
 
 from sigexport import create, data, files, html, logging, merge, utils
+from sigexport import update as update_mod
 from sigexport.export_channel_metadata import export_channel_metadata
 
 OptionalPath = Path | None
@@ -62,6 +63,12 @@ def main(
         "--overwrite/--no-overwrite",
         help="Overwrite contents of output directory if it exists",
     ),
+    update: bool = Option(
+        False,
+        "--update",
+        help="Merge this export into an existing one at DEST, keyed on message "
+        "id (incremental archive). Regenerates each chat from its data.json.",
+    ),
     yes: bool = Option(
         False,
         "--yes",
@@ -107,6 +114,15 @@ def main(
         # secho("Error: Missing argument 'DEST'", fg=colors.RED)
         raise Exit(code=1)
 
+    if update and old:
+        secho("Error: --update and --old can't be used together.", fg=colors.RED)
+        raise Exit(code=1)
+    if update and not json_output:
+        secho(
+            "--update uses data.json as its store; enabling --json.", fg=colors.YELLOW
+        )
+        json_output = True
+
     if source:
         source_dir = Path(source).expanduser().absolute()
     else:
@@ -151,7 +167,11 @@ def main(
         raise Exit()
 
     dest = Path(dest).expanduser()
-    if not dest.is_dir():
+    if update:
+        # the archive is the destination: create it on the first run, and merge
+        # into it on subsequent runs
+        dest.mkdir(parents=True, exist_ok=True)
+    elif not dest.is_dir():
         dest.mkdir(parents=True, exist_ok=True)
     elif overwrite:
         utils.safe_delete(dest, yes=yes)
@@ -187,7 +207,10 @@ def main(
     secho("Creating output files")
     chat_dict = create.create_chats(convos, contacts)
 
-    if old:
+    if update:
+        secho("Merging into existing export at destination")
+        chat_dict = update_mod.merge_into_archive(chat_dict, contacts, dest)
+    elif old:
         secho(f"Merging old at {old} into output directory")
         secho("No existing files will be deleted or overwritten!")
         chat_dict = merge.merge_with_old(chat_dict, contacts, dest, Path(old))
@@ -211,10 +234,13 @@ def main(
         js_path = dest / name / "data.json"
         ht_path = dest / name / "index.html"
 
-        md_f = md_path.open("a", encoding="utf-8")
+        # --update regenerates each chat from the merged set, so rewrite rather
+        # than append (which would duplicate the already-archived messages)
+        write_mode = "w" if update else "a"
+        md_f = md_path.open(write_mode, encoding="utf-8")
         js_f = None
         if json_output:
-            js_f = js_path.open("a", encoding="utf-8")
+            js_f = js_path.open(write_mode, encoding="utf-8")
         ht_f = None
         if html_output:
             ht_f = ht_path.open("w", encoding="utf-8")

--- a/sigexport/main.py
+++ b/sigexport/main.py
@@ -1,5 +1,6 @@
 """Main script for sigexport."""
 
+import os
 from datetime import datetime
 from pathlib import Path
 
@@ -48,6 +49,18 @@ def main(
         "--include-disappearing",
         help="Whether to include disappearing messages",
     ),
+    keep_disappearing: bool = Option(
+        False,
+        "--keep-disappearing/--no-keep-disappearing",
+        help="On --update, keep archived disappearing messages even after they "
+        "expire from Signal (default: forget them once gone)",
+    ),
+    forget_disappearing: bool = Option(
+        False,
+        "--forget-disappearing/--no-forget-disappearing",
+        help="On --update, drop all disappearing messages from the chats in "
+        "this run (sanitise an archive)",
+    ),
     start_date: str | None = Option(
         None,
         "--start",
@@ -65,7 +78,7 @@ def main(
     ),
     update: bool = Option(
         False,
-        "--update",
+        "--update/--no-update",
         help="Merge this export into an existing one at DEST, keyed on message "
         "id (incremental archive). Regenerates each chat from its data.json.",
     ),
@@ -117,6 +130,17 @@ def main(
     if update and old:
         secho("Error: --update and --old can't be used together.", fg=colors.RED)
         raise Exit(code=1)
+    if keep_disappearing and forget_disappearing:
+        secho(
+            "Error: --keep-disappearing and --forget-disappearing conflict.",
+            fg=colors.RED,
+        )
+        raise Exit(code=1)
+    if (keep_disappearing or forget_disappearing) and not update:
+        secho(
+            "Note: --keep/--forget-disappearing only apply with --update.",
+            fg=colors.YELLOW,
+        )
     if update and not json_output:
         secho(
             "--update uses data.json as its store; enabling --json.", fg=colors.YELLOW
@@ -178,7 +202,10 @@ def main(
         dest.mkdir(parents=True, exist_ok=True)
     else:
         secho(
-            f"Output folder '{dest}' already exists, didn't do anything!", fg=colors.RED
+            f"Output folder '{dest}' already exists, didn't do anything! "
+            "Use --update to merge new messages into it, or --overwrite to "
+            "replace it.",
+            fg=colors.RED,
         )
         raise Exit()
 
@@ -187,7 +214,21 @@ def main(
     if owner is not None:
         owner.name = "Note to Self"
 
-    contacts = utils.fix_names(contacts)
+    # On --update, keep known conversations in their existing folders even if
+    # their display name changed, so a rename doesn't orphan the archive.
+    pins = None
+    if update:
+        if update_mod.legacy_without_manifest(dest):
+            secho(
+                "Warning: this export has no manifest, so --update is matching "
+                "chats by folder name. If you've changed naming flags (e.g. "
+                "--nicknames) since it was created, some chats may be duplicated "
+                "rather than merged. Nothing is deleted; consider --overwrite for "
+                "a clean archive.",
+                fg=colors.YELLOW,
+            )
+        pins = update_mod.pinned_folders(dest, contacts)
+    contacts = utils.fix_names(contacts, pinned=pins)
 
     if stickers:
         secho("Exporting stickers")
@@ -209,11 +250,23 @@ def main(
 
     if update:
         secho("Merging into existing export at destination")
-        chat_dict = update_mod.merge_into_archive(chat_dict, contacts, dest)
+        chat_dict = update_mod.merge_into_archive(
+            chat_dict,
+            contacts,
+            dest,
+            reconcile_disappearing=include_disappearing,
+            keep_disappearing=keep_disappearing,
+            forget_disappearing=forget_disappearing,
+        )
     elif old:
         secho(f"Merging old at {old} into output directory")
         secho("No existing files will be deleted or overwritten!")
         chat_dict = merge.merge_with_old(chat_dict, contacts, dest, Path(old))
+
+    # Record the conversation -> folder map whenever we write the JSON store, so
+    # a later --update can match chats by stable id regardless of naming flags.
+    if json_output:
+        update_mod.save_manifest(dest, contacts, chat_dict.keys())
 
     if paginate <= 0:
         paginate = int(1e20)
@@ -235,15 +288,22 @@ def main(
         ht_path = dest / name / "index.html"
 
         # --update regenerates each chat from the merged set, so rewrite rather
-        # than append (which would duplicate the already-archived messages)
+        # than append (which would duplicate the already-archived messages).
+        # Write to temp files and atomically swap them in, so an interrupted
+        # run can't truncate or corrupt the existing archive.
         write_mode = "w" if update else "a"
-        md_f = md_path.open(write_mode, encoding="utf-8")
+        suffix = ".tmp" if update else ""
+        md_w = md_path.with_name(md_path.name + suffix)
+        js_w = js_path.with_name(js_path.name + suffix)
+        ht_w = ht_path.with_name(ht_path.name + suffix)
+
+        md_f = md_w.open(write_mode, encoding="utf-8")
         js_f = None
         if json_output:
-            js_f = js_path.open(write_mode, encoding="utf-8")
+            js_f = js_w.open(write_mode, encoding="utf-8")
         ht_f = None
         if html_output:
-            ht_f = ht_path.open("w", encoding="utf-8")
+            ht_f = ht_w.open("w", encoding="utf-8")
 
         try:
             for msg in messages:
@@ -264,6 +324,13 @@ def main(
                 js_f.close()
             if ht_f:
                 ht_f.close()
+
+        if update:
+            os.replace(md_w, md_path)
+            if json_output:
+                os.replace(js_w, js_path)
+            if html_output:
+                os.replace(ht_w, ht_path)
 
     secho("Done!", fg=colors.GREEN)
 

--- a/sigexport/models.py
+++ b/sigexport/models.py
@@ -38,6 +38,7 @@ class RawMessage:
 
     deleted: bool = False
     has_visual_media: bool = False
+    disappearing: bool = False
 
     def get_ts(self: RawMessage) -> int:
         if self.sent_at and self.server_timestamp:
@@ -174,6 +175,8 @@ class Message:
     missed: bool = False
     # Signal's stable message id, used to de-duplicate on `--update`
     id: str = ""
+    # message had a disappearing timer (only captured with --include-disappearing)
+    disappearing: bool = False
 
     def to_md(self: Message) -> str:
         date_str = self.date.strftime("%Y-%m-%d %H:%M:%S")
@@ -233,6 +236,7 @@ class Message:
             call=d.get("call", False),
             missed=d.get("missed", False),
             id=d.get("id", ""),
+            disappearing=d.get("disappearing", False),
         )
 
 

--- a/sigexport/models.py
+++ b/sigexport/models.py
@@ -172,6 +172,8 @@ class Message:
     deleted: bool = False
     call: bool = False
     missed: bool = False
+    # Signal's stable message id, used to de-duplicate on `--update`
+    id: str = ""
 
     def to_md(self: Message) -> str:
         date_str = self.date.strftime("%Y-%m-%d %H:%M:%S")
@@ -211,6 +213,27 @@ class Message:
 
     def dict_str(self: Message) -> str:
         return json.dumps(self.dict(), ensure_ascii=False)
+
+    @staticmethod
+    def from_dict(d: JsonDict) -> Message:
+        """Reconstruct a Message from a `data.json` line (see `dict`)."""
+        sticker = Sticker(**d["sticker"]) if d.get("sticker") else None
+        # reactions serialise as [name, emoji] pairs (namedtuple -> JSON array)
+        reactions = [Reaction(r[0], r[1]) for r in d.get("reactions", [])]
+        attachments = [Attachment(**a) for a in d.get("attachments", [])]
+        return Message(
+            date=datetime.fromisoformat(d["date"]),
+            sender=d["sender"],
+            body=d["body"],
+            quote=d.get("quote", ""),
+            sticker=sticker,
+            reactions=reactions,
+            attachments=attachments,
+            deleted=d.get("deleted", False),
+            call=d.get("call", False),
+            missed=d.get("missed", False),
+            id=d.get("id", ""),
+        )
 
 
 Chats = dict[str, list[Message]]

--- a/sigexport/update.py
+++ b/sigexport/update.py
@@ -7,10 +7,89 @@ back so the Markdown/HTML/JSON are all regenerated consistently.
 """
 
 import json
+from collections.abc import Iterable
 from pathlib import Path
+
+from typer import colors, secho
 
 from sigexport import models
 from sigexport.logging import log
+
+MANIFEST = "manifest.json"
+MANIFEST_VERSION = 1
+
+
+class ArchiveReadError(Exception):
+    """An archived data.json could not be fully parsed."""
+
+
+def load_manifest(dest: Path) -> dict[str, dict]:
+    """Load the archive manifest (conversation id -> folder metadata)."""
+    path = dest / MANIFEST
+    if not path.is_file():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (ValueError, OSError) as e:
+        log(f"\tCould not read {path}: {e}; ignoring")
+        return {}
+    return data.get("conversations", {})
+
+
+def pinned_folders(dest: Path, contacts: models.Contacts) -> dict[str, str]:
+    """Folders to keep stable for conversations already in the manifest."""
+    manifest = load_manifest(dest)
+    return {
+        key: entry["folder"]
+        for key, entry in manifest.items()
+        if key in contacts and entry.get("folder")
+    }
+
+
+def legacy_without_manifest(dest: Path) -> bool:
+    """True if `dest` already holds chats but has no manifest to match against.
+
+    That means it predates the manifest (an older export, or a plain one), so
+    `--update` has to fall back to matching by folder name.
+    """
+    if (dest / MANIFEST).is_file():
+        return False
+    try:
+        return any(
+            (child / "data.json").is_file()
+            for child in dest.iterdir()
+            if child.is_dir()
+        )
+    except OSError:
+        return False
+
+
+def save_manifest(
+    dest: Path, contacts: models.Contacts, exported_keys: Iterable[str]
+) -> None:
+    """Record each exported conversation's folder, preserving prior entries.
+
+    Renames are tracked: a previous display name that no longer matches is
+    kept under ``aliases``.
+    """
+    existing = load_manifest(dest)
+    conversations = dict(existing)  # keep entries for archived-only chats
+    for key in exported_keys:
+        contact = contacts[key]
+        prev = existing.get(key, {})
+        aliases = set(prev.get("aliases", []))
+        prev_display = prev.get("display")
+        if prev_display and prev_display != contact.display:
+            aliases.add(prev_display)
+        conversations[key] = {
+            "folder": contact.name,
+            "display": contact.display,
+            "aliases": sorted(aliases),
+        }
+    payload = {"format_version": MANIFEST_VERSION, "conversations": conversations}
+    (dest / MANIFEST).write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
 
 
 def _key(msg: models.Message) -> str:
@@ -25,47 +104,100 @@ def _key(msg: models.Message) -> str:
 
 
 def load_archived_messages(data_path: Path) -> list[models.Message]:
-    """Load previously-exported messages from a chat's `data.json`."""
+    """Load previously-exported messages from a chat's `data.json`.
+
+    Strict: raises `ArchiveReadError` on the first unparseable line rather than
+    dropping it, so a corrupt store never gets silently rewritten with the bad
+    line's message missing.
+    """
     messages: list[models.Message] = []
     with data_path.open(encoding="utf-8") as f:
-        for line in f:
+        for i, line in enumerate(f, 1):
             line = line.strip()
             if not line:
                 continue
             try:
                 messages.append(models.Message.from_dict(json.loads(line)))
             except (ValueError, KeyError, TypeError) as e:
-                log(f"\t\tSkipping unparseable archived message in {data_path}: {e}")
+                raise ArchiveReadError(f"{data_path} line {i}: {e}") from e
     return messages
 
 
 def merge_messages(
-    existing: list[models.Message], new: list[models.Message]
+    existing: list[models.Message],
+    new: list[models.Message],
+    *,
+    reconcile_disappearing: bool = False,
+    keep_disappearing: bool = False,
+    forget_disappearing: bool = False,
 ) -> list[models.Message]:
-    """Union `existing` and `new` by message key, newest wins, sorted by date."""
+    """Union `existing` and `new` by message key, newest wins, sorted by date.
+
+    Disappearing-message retention (all default to "respect disappearance"):
+    - ``forget_disappearing``: drop every disappearing message outright.
+    - ``reconcile_disappearing`` (i.e. this run read disappearing messages):
+      an archived disappearing message no longer present in the fresh read has
+      expired in Signal, so drop it unless ``keep_disappearing`` is set.
+    - otherwise archived disappearing messages are left untouched (we can't
+      tell "expired" from "not read this run").
+    """
+    new_keys = {_key(m) for m in new}
     by_key: dict[str, models.Message] = {}
     for msg in existing:
+        if msg.disappearing:
+            if forget_disappearing:
+                continue
+            expired = reconcile_disappearing and _key(msg) not in new_keys
+            if expired and not keep_disappearing:
+                continue
         by_key[_key(msg)] = msg
     # the current run wins on a key clash, so edits/reactions update in place
     for msg in new:
+        if forget_disappearing and msg.disappearing:
+            continue
         by_key[_key(msg)] = msg
     return sorted(by_key.values(), key=lambda m: m.date)
 
 
 def merge_into_archive(
-    chat_dict: models.Chats, contacts: models.Contacts, dest: Path
+    chat_dict: models.Chats,
+    contacts: models.Contacts,
+    dest: Path,
+    *,
+    reconcile_disappearing: bool = False,
+    keep_disappearing: bool = False,
+    forget_disappearing: bool = False,
 ) -> models.Chats:
     """Merge each current chat into whatever is already archived at `dest`.
 
     Chats that only exist in the archive (no current messages) are left
     untouched on disk. Chats new to this run are passed through unchanged.
     """
+    skipped: list[str] = []
     for key, new_msgs in chat_dict.items():
         name = contacts[key].name or "None"
         data_path = dest / name / "data.json"
         if not data_path.is_file():
             continue
-        existing = load_archived_messages(data_path)
+        try:
+            existing = load_archived_messages(data_path)
+        except ArchiveReadError as e:
+            secho(
+                f"Warning: can't read archived store ({e}); leaving '{name}' "
+                "untouched this run. Fix or remove it, then re-run.",
+                fg=colors.RED,
+            )
+            skipped.append(key)
+            continue
         log(f"\tMerging {len(new_msgs)} new into {len(existing)} archived for {name}")
-        chat_dict[key] = merge_messages(existing, new_msgs)
+        chat_dict[key] = merge_messages(
+            existing,
+            new_msgs,
+            reconcile_disappearing=reconcile_disappearing,
+            keep_disappearing=keep_disappearing,
+            forget_disappearing=forget_disappearing,
+        )
+    # don't rewrite chats whose existing store we couldn't fully read
+    for key in skipped:
+        del chat_dict[key]
     return chat_dict

--- a/sigexport/update.py
+++ b/sigexport/update.py
@@ -1,0 +1,71 @@
+"""Incremental `--update` mode: merge a fresh export into an existing one.
+
+Unlike `--old` (which re-parses the exported Markdown), this treats each chat's
+`data.json` as the canonical store: it loads the previously-exported messages,
+unions them with the current run by stable message id, and hands the merged set
+back so the Markdown/HTML/JSON are all regenerated consistently.
+"""
+
+import json
+from pathlib import Path
+
+from sigexport import models
+from sigexport.logging import log
+
+
+def _key(msg: models.Message) -> str:
+    """De-duplication key: the Signal message id, or a stable fallback.
+
+    Older archives (exported before message ids were stored) fall back to a
+    composite that is unique enough in practice.
+    """
+    if msg.id:
+        return msg.id
+    return f"{msg.date.isoformat()}|{msg.sender}|{msg.body}"
+
+
+def load_archived_messages(data_path: Path) -> list[models.Message]:
+    """Load previously-exported messages from a chat's `data.json`."""
+    messages: list[models.Message] = []
+    with data_path.open(encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                messages.append(models.Message.from_dict(json.loads(line)))
+            except (ValueError, KeyError, TypeError) as e:
+                log(f"\t\tSkipping unparseable archived message in {data_path}: {e}")
+    return messages
+
+
+def merge_messages(
+    existing: list[models.Message], new: list[models.Message]
+) -> list[models.Message]:
+    """Union `existing` and `new` by message key, newest wins, sorted by date."""
+    by_key: dict[str, models.Message] = {}
+    for msg in existing:
+        by_key[_key(msg)] = msg
+    # the current run wins on a key clash, so edits/reactions update in place
+    for msg in new:
+        by_key[_key(msg)] = msg
+    return sorted(by_key.values(), key=lambda m: m.date)
+
+
+def merge_into_archive(
+    chat_dict: models.Chats, contacts: models.Contacts, dest: Path
+) -> models.Chats:
+    """Merge each current chat into whatever is already archived at `dest`.
+
+    Chats that only exist in the archive (no current messages) are left
+    untouched on disk. Chats new to this run are passed through unchanged.
+    """
+    for key, new_msgs in chat_dict.items():
+        name = contacts[key].name or "None"
+        data_path = dest / name / "data.json"
+        if not data_path.is_file():
+            continue
+        existing = load_archived_messages(data_path)
+        log(f"\tMerging {len(new_msgs)} new into {len(existing)} archived for {name}")
+        chat_dict[key] = merge_messages(existing, new_msgs)
+    return chat_dict

--- a/sigexport/utils.py
+++ b/sigexport/utils.py
@@ -211,7 +211,9 @@ def safe_delete(dest: Path, yes: bool = False) -> None:
     shutil.rmtree(dest)
 
 
-def fix_names(contacts: models.Contacts) -> models.Contacts:
+def fix_names(
+    contacts: models.Contacts, pinned: dict[str, str] | None = None
+) -> models.Contacts:
     """Convert contact names to filesystem-friendly, de-duplicating collisions.
 
     Every contact ends up with a non-empty, unique name so each gets its own
@@ -226,8 +228,13 @@ def fix_names(contacts: models.Contacts) -> models.Contacts:
     The de-duplication suffix is only applied to ``name`` (the folder). The
     conversation-facing ``display`` keeps the un-suffixed base, so two "Alice"s
     live in Alice/ and Alice2/ but both still read "Alice" inside the export.
+
+    ``pinned`` maps a contact id to a folder it must keep (from an archive
+    manifest, for ``--update``). Pinned folders are reserved up front so a
+    renamed contact keeps its existing folder even though its display updates.
     """
-    used: set[str] = set()
+    pinned = pinned or {}
+    used: set[str] = set(pinned.values())
     for key in sorted(contacts, key=lambda k: (contacts[k].serviceId or "", k)):
         item = contacts[key]
         if item.name is None:
@@ -237,13 +244,18 @@ def fix_names(contacts: models.Contacts) -> models.Contacts:
             if base == "":
                 base = "unnamed"
 
+        item.display = base
+
+        if key in pinned:
+            item.name = pinned[key]
+            continue
+
         name = base
         suffix = 2
         while name in used:
             name = f"{base}{suffix}"
             suffix += 1
         used.add(name)
-        item.display = base
         item.name = name
 
     return contacts

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -94,6 +94,82 @@ def test_copy_attachments_sanitizes_filesystem_reserved_characters(
     assert safe_name in rendered
 
 
+CONTACT = {
+    "contact": models.Contact(
+        id="contact",
+        serviceId="service",
+        name="Alice",
+        number="",
+        profile_name="",
+        is_group=False,
+        members=None,
+    )
+}
+
+
+def _message_with_attachment() -> models.RawMessage:
+    att = {
+        "fileName": "photo.bin",
+        "contentType": "application/octet-stream",
+        "path": "ab/cd",
+        "version": "0",
+        "size": str(len(b"attachment data")),
+    }
+    return models.RawMessage(
+        conversation_id="contact",
+        id="message",
+        body="",
+        type="incoming",
+        source=None,
+        timestamp=1,
+        sent_at=None,
+        server_timestamp=None,
+        has_attachments=True,
+        attachments=[att],
+        read_status=None,
+        seen_status=None,
+        call_history=None,
+        reactions=[],
+        sticker=None,
+        quote=None,
+    )
+
+
+def test_copy_attachments_skips_already_present(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An --update re-run must not re-copy attachments already on disk."""
+    source = tmp_path / "source"
+    attachment_path = source / "attachments.noindex" / "ab" / "cd"
+    attachment_path.parent.mkdir(parents=True)
+    attachment_path.write_bytes(b"attachment data")
+    destination = tmp_path / "export"
+
+    copies: list[object] = []
+    real_copy = files.shutil.copy2
+    monkeypatch.setattr(
+        files.shutil,
+        "copy2",
+        lambda a, b, *x, **k: (copies.append(b), real_copy(a, b, *x, **k))[1],
+    )
+
+    def run() -> None:
+        # fresh RawMessage each run, as fetch_data would produce
+        with dbapi2.connect(":memory:") as connection:
+            files.copy_attachments(
+                source,
+                destination,
+                {"contact": [_message_with_attachment()]},
+                CONTACT,
+                connection.cursor(),
+            )
+
+    run()
+    assert len(copies) == 1  # first run copies
+    run()
+    assert len(copies) == 1  # second run finds it present and skips
+
+
 PNG = b"\x89PNG\r\n\x1a\n" + b"\x00" * 64
 
 

--- a/tests/test_names.py
+++ b/tests/test_names.py
@@ -119,3 +119,22 @@ def test_one_to_one_sender_uses_display() -> None:
     # a 1:1 message in conversation "b" (the de-duplicated Alice2)
     msg = create.create_message(raw(conversation_id="b"), "Alice2", False, contacts)
     assert msg.sender == "Alice"
+
+
+def test_pinned_folder_survives_a_rename() -> None:
+    """A renamed contact keeps its archive folder but shows the new name."""
+    contacts = {"a": contact("a", "Bob", "sid-a")}  # was "Alice" last export
+    utils.fix_names(contacts, pinned={"a": "Alice"})
+    assert contacts["a"].name == "Alice"  # folder unchanged
+    assert contacts["a"].display == "Bob"  # display follows the rename
+
+
+def test_new_contacts_avoid_pinned_folders() -> None:
+    """A new "Alice" can't take a folder pinned to someone else."""
+    contacts = {
+        "a": contact("a", "Alice", "sid-a"),  # pinned to Alice
+        "b": contact("b", "Alice", "sid-b"),  # new, must not clash
+    }
+    utils.fix_names(contacts, pinned={"a": "Alice"})
+    assert contacts["a"].name == "Alice"
+    assert contacts["b"].name == "Alice2"

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -9,6 +9,7 @@ def msg(
     body: str = "hi",
     sender: str = "Alice",
     mid: str = "",
+    disappearing: bool = False,
 ) -> models.Message:
     return models.Message(
         date=datetime(2024, 6, 1, 12, minute, 0),
@@ -19,6 +20,7 @@ def msg(
         reactions=[],
         attachments=[],
         id=mid,
+        disappearing=disappearing,
     )
 
 
@@ -78,13 +80,29 @@ def test_load_archived_messages(tmp_path: Path) -> None:
     assert [m.body for m in loaded] == ["one", "two"]
 
 
-def test_load_archived_messages_skips_bad_lines(tmp_path: Path) -> None:
+def test_load_archived_messages_raises_on_bad_line(tmp_path: Path) -> None:
+    import pytest
+
     data = tmp_path / "data.json"
     data.write_text(
         msg(0, "good", mid="a").dict_str() + "\n\nnot json\n", encoding="utf-8"
     )
-    loaded = update.load_archived_messages(data)
-    assert [m.body for m in loaded] == ["good"]
+    with pytest.raises(update.ArchiveReadError):
+        update.load_archived_messages(data)
+
+
+def test_merge_into_archive_leaves_corrupt_chat_untouched(tmp_path: Path) -> None:
+    """A chat whose store can't be fully read must not be rewritten (no loss)."""
+    contacts = {"c": contact("Alice")}
+    (tmp_path / "Alice").mkdir()
+    corrupt = tmp_path / "Alice" / "data.json"
+    corrupt.write_text("this is not json\n", encoding="utf-8")
+
+    chat_dict = {"c": [msg(1, "new", mid="b")]}
+    merged = update.merge_into_archive(chat_dict, contacts, tmp_path)
+    # the corrupt chat is dropped from the write set, so its files stay as-is
+    assert "c" not in merged
+    assert corrupt.read_text(encoding="utf-8") == "this is not json\n"
 
 
 def contact(name: str) -> models.Contact:
@@ -116,3 +134,113 @@ def test_merge_into_archive_passes_through_new_chat(tmp_path: Path) -> None:
     chat_dict = {"c": [msg(0, "new", mid="a")]}
     merged = update.merge_into_archive(chat_dict, contacts, tmp_path)
     assert [m.body for m in merged["c"]] == ["new"]
+
+
+# --- disappearing-message retention ---
+
+
+def test_disappearing_forgotten_when_expired() -> None:
+    """Default: a captured disappearing msg gone from the fresh read is dropped."""
+    existing = [msg(0, "vanishing", mid="a", disappearing=True), msg(1, "keep", mid="b")]
+    new = [msg(1, "keep", mid="b")]  # 'a' has expired from Signal
+    merged = update.merge_messages(existing, new, reconcile_disappearing=True)
+    assert [m.id for m in merged] == ["b"]
+
+
+def test_disappearing_kept_with_flag() -> None:
+    existing = [msg(0, "vanishing", mid="a", disappearing=True)]
+    new: list[models.Message] = []
+    merged = update.merge_messages(
+        existing, new, reconcile_disappearing=True, keep_disappearing=True
+    )
+    assert [m.id for m in merged] == ["a"]
+
+
+def test_disappearing_left_alone_when_not_reconciling() -> None:
+    """Without --include-disappearing we can't tell expired from unread, so keep."""
+    existing = [msg(0, "vanishing", mid="a", disappearing=True)]
+    merged = update.merge_messages(existing, [], reconcile_disappearing=False)
+    assert [m.id for m in merged] == ["a"]
+
+
+def test_forget_disappearing_purges_all() -> None:
+    existing = [msg(0, "gone", mid="a", disappearing=True), msg(1, "stay", mid="b")]
+    new = [msg(2, "also gone", mid="c", disappearing=True)]
+    merged = update.merge_messages(existing, new, forget_disappearing=True)
+    assert [m.id for m in merged] == ["b"]
+
+
+def test_disappearing_flag_round_trips() -> None:
+    import json
+
+    m = msg(0, "secret", mid="a", disappearing=True)
+    back = models.Message.from_dict(json.loads(m.dict_str()))
+    assert back.disappearing is True
+
+
+# --- manifest ---
+
+
+def test_manifest_round_trip_and_pins(tmp_path: Path) -> None:
+    contacts = {"c1": contact("Alice"), "c2": contact("Bob")}
+    contacts["c1"].display = "Alice"
+    contacts["c2"].display = "Bob"
+    update.save_manifest(tmp_path, contacts, ["c1", "c2"])
+
+    pins = update.pinned_folders(tmp_path, contacts)
+    assert pins == {"c1": "Alice", "c2": "Bob"}
+
+
+def test_manifest_records_rename_alias(tmp_path: Path) -> None:
+    contacts = {"c1": contact("Alice")}
+    contacts["c1"].display = "Alice"
+    update.save_manifest(tmp_path, contacts, ["c1"])
+
+    # next run: same conversation, renamed to Bob (folder pinned to Alice)
+    contacts["c1"].name = "Alice"
+    contacts["c1"].display = "Bob"
+    update.save_manifest(tmp_path, contacts, ["c1"])
+
+    manifest = update.load_manifest(tmp_path)
+    assert manifest["c1"]["display"] == "Bob"
+    assert "Alice" in manifest["c1"]["aliases"]
+
+
+def test_pinned_folders_ignores_unknown_conversations(tmp_path: Path) -> None:
+    contacts = {"c1": contact("Alice")}
+    contacts["c1"].display = "Alice"
+    update.save_manifest(tmp_path, contacts, ["c1"])
+    # a different run with a different conversation set
+    assert update.pinned_folders(tmp_path, {"other": contact("Zed")}) == {}
+
+
+def test_legacy_without_manifest_detection(tmp_path: Path) -> None:
+    assert update.legacy_without_manifest(tmp_path) is False  # empty
+    chat = tmp_path / "Alice"
+    chat.mkdir()
+    (chat / "data.json").write_text("{}", encoding="utf-8")
+    assert update.legacy_without_manifest(tmp_path) is True  # chats, no manifest
+    c = contact("Alice")
+    c.display = "Alice"
+    update.save_manifest(tmp_path, {"c1": c}, ["c1"])
+    assert update.legacy_without_manifest(tmp_path) is False  # now has manifest
+
+
+def test_toggling_nicknames_keeps_folder_stable(tmp_path: Path) -> None:
+    """Plain export names by nickname; a later --update without --nicknames must
+    keep the folder (via the manifest) instead of orphaning it."""
+    from sigexport import utils
+
+    # run 1: nickname naming -> folder "Nocturnal"
+    nick = contact("Nocturnal")
+    contacts = {"c1": nick}
+    utils.fix_names(contacts, pinned=None)
+    update.save_manifest(tmp_path, contacts, ["c1"])
+    assert contacts["c1"].name == "Nocturnal"
+
+    # run 2: same conversation, profile naming -> would be "KC" without a pin
+    contacts = {"c1": contact("KC")}
+    pins = update.pinned_folders(tmp_path, contacts)
+    utils.fix_names(contacts, pinned=pins)
+    assert contacts["c1"].name == "Nocturnal"  # folder held stable
+    assert contacts["c1"].display == "KC"  # display follows the current run

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -1,0 +1,118 @@
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from sigexport import models, update
+
+
+def msg(
+    minute: int = 0,
+    body: str = "hi",
+    sender: str = "Alice",
+    mid: str = "",
+) -> models.Message:
+    return models.Message(
+        date=datetime(2024, 6, 1, 12, minute, 0),
+        sender=sender,
+        body=body,
+        quote="",
+        sticker=None,
+        reactions=[],
+        attachments=[],
+        id=mid,
+    )
+
+
+def test_message_round_trips_through_dict() -> None:
+    original = models.Message(
+        date=datetime(2024, 6, 1, 14, 3, 5),
+        sender="Alice",
+        body="hello",
+        quote="\n\n> earlier\n\n",
+        sticker=models.Sticker(id="1", packId="p", packKey="k", emoji="x"),
+        reactions=[models.Reaction("Bob", "👍")],
+        attachments=[models.Attachment(name="cat.jpg", path="media/cat.jpg")],
+        deleted=True,
+        id="guid-1",
+    )
+    import json
+
+    assert models.Message.from_dict(json.loads(original.dict_str())) == original
+
+
+def test_merge_unions_by_id() -> None:
+    existing = [msg(0, "one", mid="a"), msg(1, "two", mid="b")]
+    new = [msg(2, "three", mid="c")]
+    merged = update.merge_messages(existing, new)
+    assert [m.body for m in merged] == ["one", "two", "three"]
+
+
+def test_merge_new_wins_on_id_collision() -> None:
+    """An edited message (same id) should replace the archived copy."""
+    existing = [msg(0, "typo", mid="a")]
+    new = [msg(0, "fixed", mid="a")]
+    merged = update.merge_messages(existing, new)
+    assert len(merged) == 1
+    assert merged[0].body == "fixed"
+
+
+def test_merge_sorts_by_date() -> None:
+    existing = [msg(5, "late", mid="a")]
+    new = [msg(1, "early", mid="b")]
+    merged = update.merge_messages(existing, new)
+    assert [m.body for m in merged] == ["early", "late"]
+
+
+def test_merge_without_ids_falls_back_to_composite_key() -> None:
+    """Legacy archives have no ids; dedup on date+sender+body instead."""
+    existing = [msg(0, "same", sender="Alice")]
+    new = [msg(0, "same", sender="Alice"), msg(1, "different")]
+    merged = update.merge_messages(existing, new)
+    assert len(merged) == 2  # the identical one de-duped, the new one kept
+
+
+def test_load_archived_messages(tmp_path: Path) -> None:
+    data = tmp_path / "data.json"
+    lines = [msg(0, "one", mid="a").dict_str(), msg(1, "two", mid="b").dict_str()]
+    data.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    loaded = update.load_archived_messages(data)
+    assert [m.body for m in loaded] == ["one", "two"]
+
+
+def test_load_archived_messages_skips_bad_lines(tmp_path: Path) -> None:
+    data = tmp_path / "data.json"
+    data.write_text(
+        msg(0, "good", mid="a").dict_str() + "\n\nnot json\n", encoding="utf-8"
+    )
+    loaded = update.load_archived_messages(data)
+    assert [m.body for m in loaded] == ["good"]
+
+
+def contact(name: str) -> models.Contact:
+    return models.Contact(
+        id="c",
+        serviceId="s",
+        name=name,
+        number="",
+        profile_name="",
+        is_group=False,
+        members=None,
+    )
+
+
+def test_merge_into_archive_merges_existing_chat(tmp_path: Path) -> None:
+    contacts = {"c": contact("Alice")}
+    (tmp_path / "Alice").mkdir()
+    archived = tmp_path / "Alice" / "data.json"
+    archived.write_text(msg(0, "old", mid="a").dict_str() + "\n", encoding="utf-8")
+
+    chat_dict = {"c": [msg(1, "new", mid="b")]}
+    merged = update.merge_into_archive(chat_dict, contacts, tmp_path)
+    assert [m.body for m in merged["c"]] == ["old", "new"]
+
+
+def test_merge_into_archive_passes_through_new_chat(tmp_path: Path) -> None:
+    """A chat with no existing folder is left as-is (first export of it)."""
+    contacts = {"c": contact("Alice")}
+    chat_dict = {"c": [msg(0, "new", mid="a")]}
+    merged = update.merge_into_archive(chat_dict, contacts, tmp_path)
+    assert [m.body for m in merged["c"]] == ["new"]


### PR DESCRIPTION
Implements #222: a `--update` mode that accumulates a Signal export over time, replacing the sharp edges of `--old` with an id-keyed canonical store. Built to be safe to point at a real archive.

`--update` is a third mode for an existing output directory (alongside refuse and `--overwrite`): it merges the current export into it **in place**. Each chat's `data.json` is the **canonical store**; Markdown/HTML/JSON are all regenerated from the merged set, so nothing round-trips through Markdown.

## Core
- `Message` carries Signal's stable message `id`, with `from_dict()` to reconstruct from a `data.json` line.
- Merge unions the current chat with its archived store **by message id** (composite `date+sender+body` fallback for pre-id archives). Freshest read wins, so **edits and reaction changes update in place**. Chats that only exist in the archive are left untouched.
- `--update` implies `--json` (its store) and is mutually exclusive with `--old`. First run on a fresh dir just creates the archive.

## Rename-stable matching
- A `manifest.json` (conversation id → folder, display, rename aliases) is written on every JSON export, so the map exists from day one.
- On `--update`, known conversations **keep their existing folder even when the display name changes** (e.g. toggling `--nicknames`) — a rename never orphans the archive. New conversations avoid pinned folders when de-duping.
- A legacy archive with no manifest gets a clear warning that matching falls back to folder name; worst case there is a duplicate folder, **never deletion**.

## Disappearing messages (defaults to respecting disappearance)
- Captured only under the existing `--include-disappearing`; a `disappearing` flag is stored per message.
- On `--update --include-disappearing`, an archived disappearing message no longer in the fresh read has expired and is dropped. Without that flag we can't tell expired from unread, so archived ones are left alone.
- `--keep-disappearing` retains them past expiry; `--forget-disappearing` purges them from the run's chats (sanitise).

## Data-safety & speed
- A chat whose `data.json` can't be fully parsed is left **completely untouched** (with a warning) rather than silently dropping the bad line and overwriting.
- Views are written to temp files and **atomically swapped in** (`os.replace`), so an interrupted run can't truncate the store.
- `copy_attachments` **skips attachments already present** at the expected size, so a re-run no longer re-decrypts every attachment.

## Polish
- The three new flags have `--no-` forms; the "folder already exists" message now points at `--update`.

## Deferred (per #222)
- An `--import-legacy` bridge to seed the manifest from a pre-existing Markdown export (until then, first `--update` of a legacy archive should keep naming flags consistent).

## Tests
`tests/test_update.py`, plus additions to `test_names.py` and `test_files.py`: round-trip, union-by-id, edit-wins, id-less fallback, corrupt-store skip, manifest round-trip/aliases/legacy detection, folder pinning, cross-flag folder stability, every disappearing path, and the attachment skip. Full suite green, lint/type clean.