### PR TITLE
Show your own reactions as "Me", not "Note to Self"

### DIFF
--- a/sigexport/create.py
+++ b/sigexport/create.py
@@ -151,9 +151,13 @@ def create_message(
         for r in msg.reactions:
             try:
                 reactor = contacts[r["fromId"]]
-                reactions.append(
-                    models.Reaction(reactor.display or reactor.name, r["emoji"])
-                )
+                # your own reactions read "Me", matching how your messages show,
+                # rather than the owner conversation's "Note to Self" folder name
+                if reactor.is_owner:
+                    reactor_name = "Me"
+                else:
+                    reactor_name = reactor.display or reactor.name
+                reactions.append(models.Reaction(reactor_name, r["emoji"]))
             except KeyError:
                 log(
                     f"\t\tReaction fromId not found in contacts: [{date}] {sender}: {r}"

--- a/sigexport/main.py
+++ b/sigexport/main.py
@@ -164,8 +164,10 @@ def main(
 
     # The conversation with your own account is Signal's "Note to Self"; it
     # usually has no name and would otherwise land in the shared "None" folder.
+    # Mark it so your own reactions read "Me" rather than the folder name.
     if owner is not None:
         owner.name = "Note to Self"
+        owner.is_owner = True
 
     contacts = utils.fix_names(contacts)
 

--- a/sigexport/models.py
+++ b/sigexport/models.py
@@ -103,6 +103,8 @@ class Contact:
     # reactions, HTML title). Unlike `name`, it has no folder-uniqueness
     # suffix, so two "Alice"s live in Alice/ and Alice2/ but both read "Alice".
     display: str | None = None
+    # the db owner (you): shown as "Me", so reactions don't read "Note to Self"
+    is_owner: bool = False
 
 
 Contacts = dict[str, Contact]

--- a/tests/test_names.py
+++ b/tests/test_names.py
@@ -119,3 +119,31 @@ def test_one_to_one_sender_uses_display() -> None:
     # a 1:1 message in conversation "b" (the de-duplicated Alice2)
     msg = create.create_message(raw(conversation_id="b"), "Alice2", False, contacts)
     assert msg.sender == "Alice"
+
+
+def test_own_reactions_show_as_me_not_note_to_self() -> None:
+    """Your own reactions must read 'Me', not the owner folder's 'Note to Self'."""
+    owner = contact("me", "Note to Self", "sid-me")
+    owner.is_owner = True
+    owner.display = "NotetoSelf"  # as fix_names would set it
+    contacts = {"me": owner, "c": contact("c", "Alice", "sid-a")}
+    contacts["c"].display = "Alice"
+    msg = create.create_message(
+        raw(conversation_id="c", reactions=[{"fromId": "me", "emoji": "👍"}]),
+        "Alice",
+        False,
+        contacts,
+    )
+    assert msg.reactions == [models.Reaction("Me", "👍")]
+
+
+def test_other_peoples_reactions_use_their_display() -> None:
+    contacts = {"c": contact("c", "Alice", "sid-a")}
+    contacts["c"].display = "Alice"
+    msg = create.create_message(
+        raw(conversation_id="c", reactions=[{"fromId": "c", "emoji": "❤️"}]),
+        "Alice",
+        False,
+        contacts,
+    )
+    assert msg.reactions == [models.Reaction("Alice", "❤️")]


### PR DESCRIPTION
Since the owner conversation is renamed to "Note to Self" for its folder (#217), and reaction authors are labelled from the reactor's display name, **your own reactions rendered as "Note to Self"** (or `NotetoSelf`) in every chat — even though your *messages* correctly show "Me". Most visible with `--nicknames`, but present regardless.

Fix: mark the owner contact (`is_owner`) and attribute their reactions as "Me", matching how their messages are shown. Everyone else's reactions are unchanged. Applies to both the Markdown and HTML output (both build from `Message.reactions`).

Adds tests for the owner-reaction and other-people's-reaction paths.