### PR TITLE
fix: keep voice notes visible in continuation bubbles

### DIFF
--- a/sigexport/style.css
+++ b/sigexport/style.css
@@ -396,7 +396,8 @@ label > img {
 
 audio {
     display: block;
-    width: min(320px, 100%);
+    width: 320px;
+    max-width: 100%;
     margin-top: 0.4rem;
 }
 


### PR DESCRIPTION
### Problem

In HTML exports, a streak of voice notes from the same person only shows the first one. The rest are in the DOM but render at 0px width.

This happens on continuation bubbles (`.msg.cont`). Those bubbles often contain only an `<audio>` element, and the bubble itself is `width: fit-content`. Audio was sized with `width: min(320px, 100%)`, so the parent and child depended on each other for width and collapsed.

Images in the same streak still showed up because they have an intrinsic size.

### Fix

Give audio a fixed width and cap it with max-width:

```css
audio {
    display: block;
    width: 320px;
    max-width: 100%;
    margin-top: 0.4rem;
}
```

### Before / after

Same chat, four messages in a row: voice, voice, image, voice.

**Before** (2nd and 4th voice notes missing):

![before](https://raw.githubusercontent.com/Mateleo/signal-export/pr-229-screenshots/pr-assets/before-redacted.png)

**After** (all three players visible):

![after](https://raw.githubusercontent.com/Mateleo/signal-export/pr-229-screenshots/pr-assets/after-redacted.png)

### Test plan

- [x] Reproduced on a real export with consecutive voice notes
- [x] Confirmed collapsed geometry with Playwright (`width: 0` on cont audio)
- [x] Confirmed fixed geometry after the CSS change (`width: 320`)
- [ ] Open an HTML export with several voice notes in a row and check they all show controls
